### PR TITLE
Build out an initial github workflow for building/deploying the operator

### DIFF
--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -34,13 +34,3 @@ jobs:
           export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
           export MO_TAGS=$(cat ./build/tagsToPush.txt)
           sudo -E env "PATH=$PATH" mage operator:deployToECR
-      - name: Deploy to Artifactory
-        if: github.ref == 'master'
-        env: 
-          MO_ART_USR: ${{ secrets.ART_USR }}
-          MO_ART_PSW: ${{ secrets.ART_PSW }}
-          MO_ART_REPO: ${{ secrets.ART_REPO }}
-        run: |
-          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-          export MO_TAGS=$(cat ./build/tagsToPush.txt)
-          sudo -E env "PATH=$PATH" mage operator:deployToArtifactory

--- a/.github/workflows/operatorStableBuildAndDeploy.yml
+++ b/.github/workflows/operatorStableBuildAndDeploy.yml
@@ -1,0 +1,48 @@
+name: Cass Operator Stable Build & Deploy
+on:
+  push:
+    branches:    
+      - master
+jobs:
+  build_operator_docker:
+    name: Build Cass Operator Docker Image
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/go
+      GOROOT: /usr/local/go1.13
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Install Mage
+        run: |
+          cd /tmp
+          wget https://github.com/magefile/mage/releases/download/v1.9.0/mage_1.9.0_Linux-64bit.tar.gz
+          tar -xvf mage_1.9.0_Linux-64bit.tar.gz
+          sudo mkdir -p $GOPATH/bin
+          sudo mv mage $GOPATH/bin/mage
+          sudo chmod +x $GOPATH/bin/mage
+      - name: Build docker
+        run: |
+          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+          sudo -E env "PATH=$PATH" mage operator:buildDocker
+      - name: Deploy to ECR
+        env: 
+          MO_ECR_ID: ${{ secrets.ECR_ID }}
+          MO_ECR_SECRET: ${{ secrets.ECR_SECRET }}
+          MO_ECR_REPO: ${{ secrets.ECR_REPO }}
+        run: |
+          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+          export MO_TAGS=$(cat ./build/tagsToPush.txt)
+          sudo -E env "PATH=$PATH" mage operator:deployToECR
+      - name: Deploy to Artifactory
+        env: 
+          MO_ART_USR: ${{ secrets.ART_USR }}
+          MO_ART_PSW: ${{ secrets.ART_PSW }}
+          MO_ART_REPO: ${{ secrets.ART_REPO }}
+        run: |
+          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+          export MO_TAGS=$(cat ./build/tagsToPush.txt)
+          sudo -E env "PATH=$PATH" mage operator:deployToArtifactory


### PR DESCRIPTION
Build out stable / PR workflows for running the `mage operator:dockerBuild` and deployment targets.