### PR TITLE
KO-358 Update workflow to not attempt an ECR publish from a fork PR

### DIFF
--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -8,7 +8,30 @@ jobs:
       GOPATH: /home/runner/go
       GOROOT: /usr/local/go1.13
     steps:
-      - name: Test actions property
-        if: github.repository == 'datastax/cass-operator'
+      - uses: actions/checkout@v2
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Install Mage
         run: |
-          echo "repository check success"
+          cd /tmp
+          wget https://github.com/magefile/mage/releases/download/v1.9.0/mage_1.9.0_Linux-64bit.tar.gz
+          tar -xvf mage_1.9.0_Linux-64bit.tar.gz
+          sudo mkdir -p $GOPATH/bin
+          sudo mv mage $GOPATH/bin/mage
+          sudo chmod +x $GOPATH/bin/mage
+      - name: Build docker
+        run: |
+          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+          sudo -E env "PATH=$PATH" mage operator:buildDocker
+      - name: Deploy to ECR
+        if: github.repository == 'datastax/cass-operator'
+        env:
+          MO_ECR_ID: ${{ secrets.ECR_ID }}
+          MO_ECR_SECRET: ${{ secrets.ECR_SECRET }}
+          MO_ECR_REPO: ${{ secrets.ECR_REPO }}
+        run: |
+          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+          export MO_TAGS=$(cat ./build/tagsToPush.txt)
+          sudo -E env "PATH=$PATH" mage operator:deployToECR

--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -8,6 +8,11 @@ jobs:
       GOPATH: /home/runner/go
       GOROOT: /usr/local/go1.13
     steps:
+      - name: Test actions property
+        env: 
+         ACTOR: github.actor
+        run: |
+          echo "ACTOR: ${ACTOR}"
       - uses: actions/checkout@v2
       - name: Set up Go 1.13
         uses: actions/setup-go@v1

--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -9,31 +9,6 @@ jobs:
       GOROOT: /usr/local/go1.13
     steps:
       - name: Test actions property
+        if: github.repository == "datastax/cass-operator"
         run: |
-          echo "repo: ${GITHUB_REPOSITORY}"
-      - uses: actions/checkout@v2
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-      - name: Install Mage
-        run: |
-          cd /tmp
-          wget https://github.com/magefile/mage/releases/download/v1.9.0/mage_1.9.0_Linux-64bit.tar.gz
-          tar -xvf mage_1.9.0_Linux-64bit.tar.gz
-          sudo mkdir -p $GOPATH/bin
-          sudo mv mage $GOPATH/bin/mage
-          sudo chmod +x $GOPATH/bin/mage
-      - name: Build docker
-        run: |
-          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-          sudo -E env "PATH=$PATH" mage operator:buildDocker
-      - name: Deploy to ECR
-        env: 
-          MO_ECR_ID: ${{ secrets.ECR_ID }}
-          MO_ECR_SECRET: ${{ secrets.ECR_SECRET }}
-          MO_ECR_REPO: ${{ secrets.ECR_REPO }}
-        run: |
-          export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-          export MO_TAGS=$(cat ./build/tagsToPush.txt)
-          sudo -E env "PATH=$PATH" mage operator:deployToECR
+          echo "repository check success"

--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Test actions property
         run: |
-          echo "ACTOR: ${GITHUB_ACTOR}"
+          echo "repo: ${GITHUB_REPOSITORY}"
       - uses: actions/checkout@v2
       - name: Set up Go 1.13
         uses: actions/setup-go@v1

--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -9,10 +9,8 @@ jobs:
       GOROOT: /usr/local/go1.13
     steps:
       - name: Test actions property
-        env: 
-         ACTOR: github.actor
         run: |
-          echo "ACTOR: ${ACTOR}"
+          echo "ACTOR: ${GITHUB_ACTOR}"
       - uses: actions/checkout@v2
       - name: Set up Go 1.13
         uses: actions/setup-go@v1

--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -9,6 +9,6 @@ jobs:
       GOROOT: /usr/local/go1.13
     steps:
       - name: Test actions property
-        if: github.repository == "datastax/cass-operator"
+        if: github.repository == 'datastax/cass-operator'
         run: |
           echo "repository check success"


### PR DESCRIPTION
When running the PR check coming from a fork, we don't want to attempt the ECR publish step.