### PR TITLE
include jvm-options change in config change integration test

### DIFF
--- a/tests/config_change/config_change_suite_test.go
+++ b/tests/config_change/config_change_suite_test.go
@@ -94,7 +94,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForOutputAndLog(step, k, "Ready", 1800)
 
 			step = "change the config"
-			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"file_cache_size_in_mb\": 123}}}}"
+			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"file_cache_size_in_mb\": 123}, \"jvm-options\": {\"garbage_collector\": \"CMS\"}}}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 
@@ -110,11 +110,12 @@ var _ = Describe(testName, func() {
 				FormatOutput(json)
 			ns.WaitForOutputAndLog(step, k, "Ready", 1800)
 
-			step = "checking that the init container got the updated config file_cache_size_in_mb=123"
+			step = "checking that the init container got the updated config file_cache_size_in_mb=123, garbage_collector=CMS"
 			json = "jsonpath={.spec.initContainers[0].env[0].value}"
 			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").
 				FormatOutput(json)
 			ns.WaitForOutputContainsAndLog(step, k, "\"file_cache_size_in_mb\":123", 30)
+			ns.WaitForOutputContainsAndLog(step, k, "\"garbage_collector\":\"CMS\"", 30)
 
 			step = "deleting the dc"
 			k = kubectl.DeleteFromFiles(dcYaml)

--- a/tests/config_change/config_change_suite_test.go
+++ b/tests/config_change/config_change_suite_test.go
@@ -94,7 +94,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForOutputAndLog(step, k, "Ready", 1800)
 
 			step = "change the config"
-			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"file_cache_size_in_mb\": 123}, \"jvm-options\": {\"garbage_collector\": \"CMS\"}}}}"
+			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"file_cache_size_in_mb\": 123}, \"jvm-server-options\": {\"garbage_collector\": \"CMS\"}}}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 


### PR DESCRIPTION
Note that this is a WIP. 

I thought it would be good to have test coverage for changes to `jvm-options`. It also serves as documentation. I had to spend time hunting through the [cass-config-definitions](https://github.com/datastax/cass-config-definitions) and the [cass-config-builder](https://github.com/datastax/cass-config-builder) repos to figure out how to make some changes.

I have some local changes not included with this commit that were necessary to get the test working with Cassandra 3.11.x (see #25 and #26 for details). The test in master currently only works with DSE.

For this PR I would like to update the existing to to include the `jvm-options` change and then add a variation to test against Cassandra. Given how the integration tests are structured I am not sure how best to proceed. 