### PR TITLE
KO-376 use a better github property for checking where a PR originated from

### DIFF
--- a/.github/workflows/operatorPRBuildAndDeploy.yml
+++ b/.github/workflows/operatorPRBuildAndDeploy.yml
@@ -26,7 +26,7 @@ jobs:
           export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
           mage operator:testAndBuild
       - name: Deploy to ECR
-        if: github.repository == 'datastax/cass-operator'
+        if: github.event.pull_request.head.repo.full_name == 'datastax/cass-operator'
         env:
           MO_ECR_ID: ${{ secrets.ECR_ID }}
           MO_ECR_SECRET: ${{ secrets.ECR_SECRET }}


### PR DESCRIPTION
The `github.event.pull_request.head.repo.full_name`  property seems to properly store the repo that a PR originated from, and can be used to guard against fork PRs running certain steps.

Test runs for this property:
From a fork PR: https://github.com/datastax/cass-operator/runs/574119922?check_suite_focus=true
From a regular PR: https://github.com/datastax/cass-operator/runs/574121100?check_suite_focus=true
