### PR TITLE
Events for mutations

### DIFF
--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -41,6 +41,23 @@ const (
 	// Progress states for status
 	ProgressUpdating ProgressState = "Updating"
 	ProgressReady    ProgressState = "Ready"
+
+	// Events
+	UpdatingRack                      string = "UpdatingRack"
+	StoppingDatacenter                string = "StoppingDatacenter"
+	DeletingStuckPod                  string = "DeletingStuckPod"
+	RestartingCassandra               string = "RestartingCassandra"
+	CreatedResource                   string = "CreatedResource"
+	StartedCassandra                  string = "StartedCassandra"
+	LabeledPodAsSeed                  string = "LabeledPodAsSeed"
+	UnlabeledPodAsSeed                string = "UnlabeledPodAsSeed"
+	LabeledRackResource               string = "LabeledRackResource"
+	ScalingUpRack                     string = "ScalingUpRack"
+	CreatedSuperuser                  string = "CreatedSuperuser"
+	FinishedReplaceNode               string = "FinishedReplaceNode"
+	ReplacingNode                     string = "ReplacingNode"
+	StartingCassandraAndReplacingNode string = "StartingCassandraAndReplacingNode"
+	StartingCassandra                 string = "StartingCassandra"
 )
 
 // This type exists so there's no chance of pushing random strings to our progress status

--- a/operator/pkg/reconciliation/handler.go
+++ b/operator/pkg/reconciliation/handler.go
@@ -191,6 +191,6 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileCassandraDatacenter{
 		client:   mgr.GetClient(),
 		scheme:   mgr.GetScheme(),
-		recorder: mgr.GetEventRecorderFor("cassandra-operator"),
+		recorder: mgr.GetEventRecorderFor("cass-operator"),
 	}
 }

--- a/operator/pkg/reconciliation/reconcile_racks.go
+++ b/operator/pkg/reconciliation/reconcile_racks.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"time"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -194,6 +195,9 @@ func (rc *ReconciliationContext) CheckRackPodTemplate() result.ReconcileResult {
 
 		if needsUpdate {
 
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "UpdatingRack",
+				"Updating rack %s", rackName)
+
 			if err := setOperatorProgressStatus(rc, api.ProgressUpdating); err != nil {
 				return result.Error(err)
 			}
@@ -271,6 +275,9 @@ func (rc *ReconciliationContext) CheckRackLabels() result.ReconcileResult {
 				// FIXME we had not been passing this error up - why?
 				return result.Error(err)
 			}
+
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "UpateRackLabelsOnResource",
+				"Update rack labels for StatefulSet %s", statefulSet.Name)
 		}
 	}
 
@@ -280,6 +287,7 @@ func (rc *ReconciliationContext) CheckRackLabels() result.ReconcileResult {
 func (rc *ReconciliationContext) CheckRackStoppedState() result.ReconcileResult {
 	logger := rc.ReqLogger
 
+	emittedStoppingEvent := false
 	racksUpdated := false
 	for idx := range rc.desiredRackInformation {
 		rackInfo := rc.desiredRackInformation[idx]
@@ -294,6 +302,12 @@ func (rc *ReconciliationContext) CheckRackStoppedState() result.ReconcileResult 
 				"rack", rackInfo.RackName,
 				"currentSize", currentPodCount,
 			)
+
+			if !emittedStoppingEvent {
+				rc.Recorder.Eventf(rc.Datacenter, "Normal", "StoppingDatacenter",
+					"Stopping datacenter")
+				emittedStoppingEvent = true
+			}
 
 			rackPods := FilterPodListByLabels(rc.dcPods, rc.Datacenter.GetRackLabels(rackInfo.RackName))
 
@@ -473,6 +487,9 @@ func (rc *ReconciliationContext) CheckRackScale() result.ReconcileResult {
 				"desiredSize", desiredNodeCount,
 			)
 
+			rc.Recorder.Eventf(rc.Datacenter, "ScaleUpRack",
+				"Scaling up rack %s", rackInfo.RackName)
+
 			err := rc.UpdateRackNodeCount(statefulSet, desiredNodeCount)
 			if err != nil {
 				return result.Error(err)
@@ -528,6 +545,9 @@ func (rc *ReconciliationContext) CreateSuperuser() result.ReconcileResult {
 	}
 
 	rc.ReqLogger.Info("reconcile_racks::CreateSuperuser")
+
+	rc.Recorder.Eventf(rc.Datacenter, "Normal", "CreateSuperuser",
+		"Creating superuser")
 
 	// Get the secret
 	secret, err := rc.retrieveSuperuserSecret()
@@ -658,6 +678,10 @@ func (rc *ReconciliationContext) updateCurrentReplacePodsProgress() error {
 			// Since pod is labeled as started, it should be done being replaced
 			if findValueIndexFromStringArray(dc.Status.NodeReplacements, pod.Name) > -1 {
 				logger.Info("Finished replacing pod", "pod", pod.Name)
+
+				rc.Recorder.Eventf(rc.Datacenter, "Normal", "FinishReplaceNode",
+					"Finished replacing pod %s", pod.Name)
+
 				dc.Status.NodeReplacements = removeValueFromStringArray(dc.Status.NodeReplacements, pod.Name)
 			}
 		}
@@ -670,6 +694,11 @@ func (rc *ReconciliationContext) startReplacePodsIfReplacePodsSpecified() error 
 	dc := rc.Datacenter
 	if len(dc.Spec.ReplaceNodes) > 0 {
 		rc.ReqLogger.Info("Replacing pods", "pods", dc.Spec.ReplaceNodes)
+
+		podNamesString := strings.Join(dc.Spec.ReplaceNodes, ", ")
+		rc.Recorder.Eventf(rc.Datacenter, "Normal", "StartReplaceNode",
+			"Replacing Cassandra nodes for pods %s", podNamesString)
+
 		dc.Status.NodeReplacements = appendValuesToStringArrayIfNotPresent(
 			dc.Status.NodeReplacements,
 			dc.Spec.ReplaceNodes...)
@@ -824,6 +853,8 @@ func (rc *ReconciliationContext) deleteStuckNodes() (bool, error) {
 
 		if shouldDelete {
 			rc.ReqLogger.Info(fmt.Sprintf("Deleting stuck pod: %s. Reason: %s", pod.Name, reason))
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "DeletingStuckPod",
+				reason)
 			return true, rc.Client.Delete(rc.Ctx, pod)
 		}
 	}
@@ -879,11 +910,17 @@ func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (int, 
 
 		shouldUpdate := false
 		if isSeed && currentVal != "true" {
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "SetPodAsSeed",
+				"Making pod %s a seed node", pod.Name)
+
 			newLabels[api.SeedNodeLabel] = "true"
 			shouldUpdate = true
 		}
 		// if this pod is starting, we should leave the seed label alone
 		if !isSeed && currentVal == "true" && !starting {
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "UnsetPodAsSeed",
+				"Making pod %s a non-seed node", pod.Name)
+
 			delete(newLabels, api.SeedNodeLabel)
 			shouldUpdate = true
 		}
@@ -1098,6 +1135,9 @@ func (rc *ReconciliationContext) ReconcilePods(statefulSet *appsv1.StatefulSet) 
 					"Pod", podName,
 				)
 			}
+
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "UpateRackLabelsOnResource",
+				"Update rack labels for Pod %s", podName)
 		}
 
 		if pod.Spec.Volumes == nil || len(pod.Spec.Volumes) == 0 || pod.Spec.Volumes[0].PersistentVolumeClaim == nil {
@@ -1150,6 +1190,9 @@ func (rc *ReconciliationContext) ReconcilePods(statefulSet *appsv1.StatefulSet) 
 					"PVC", pvc,
 				)
 			}
+
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "UpateRackLabelsOnResource",
+				"Update rack labels for PersistentVolumeClaim %s", pvc.Name)
 		}
 	}
 
@@ -1198,6 +1241,7 @@ func (rc *ReconciliationContext) labelServerPodStarting(pod *corev1.Pod) error {
 	if err != nil {
 		return err
 	}
+	
 	statusPatch := client.MergeFrom(dc.DeepCopy())
 	dc.Status.LastServerNodeStarted = metav1.Now()
 	err = rc.Client.Status().Patch(ctx, dc, statusPatch)
@@ -1231,6 +1275,8 @@ func (rc *ReconciliationContext) findStartingNodes() (bool, error) {
 	for _, pod := range rc.clusterPods {
 		if pod.Labels[api.CassNodeState] == stateStarting {
 			if isServerReady(pod) {
+				rc.Recorder.Eventf(rc.Datacenter, "Normal", "StartedCassandra",
+					"Started Cassandra for pod %s", pod.Name)
 				if err := rc.labelServerPodStarted(pod); err != nil {
 					return false, err
 				}
@@ -1304,10 +1350,14 @@ func (rc *ReconciliationContext) startCassandra(endpointData httphelper.CassMeta
 		// If we have a replace address that means the cassandra node did
 		// join the ring previously and is marked for replacement, so we
 		// start it accordingly
+		rc.Recorder.Eventf(rc.Datacenter, "Normal", "StartCassandraAndReplaceNode",
+			"Starting Cassandra for pod %s to replace Cassandra node with address %s", pod.Name, replaceAddress)
 		err = mgmtClient.CallLifecycleStartEndpointWithReplaceIp(pod, replaceAddress)
 	} else {
 		// Either we are not replacing this pod or the relevant cassandra node
 		// never joined the ring in the first place and can be started normally
+		rc.Recorder.Eventf(rc.Datacenter, "Normal", "StartCassandra",
+			"Starting Cassandra for pod %s", pod.Name)
 		err = mgmtClient.CallLifecycleStartEndpoint(pod)
 	}
 
@@ -1358,6 +1408,10 @@ func (rc *ReconciliationContext) startOneNodePerRack(endpointData httphelper.Cas
 					if err := rc.Client.Patch(rc.Ctx, pod, patch); err != nil {
 						return "", err
 					}
+
+					rc.Recorder.Eventf(rc.Datacenter, "Normal", "SetPodAsSeed",
+						"Making pod %s a seed node", pod.Name)
+
 					// sleeping five seconds for DNS paranoia
 					time.Sleep(5 * time.Second)
 				}
@@ -1541,6 +1595,9 @@ func (rc *ReconciliationContext) CheckRollingRestart() result.ReconcileResult {
 	for _, pod := range rc.dcPods {
 		podStartTime := pod.GetCreationTimestamp()
 		if podStartTime.Before(cutoff) {
+			rc.Recorder.Eventf(rc.Datacenter, "Normal", "RestartingCassandra",
+				"Restarting Cassandra for pod %s", pod.Name)
+
 			// drain the node
 			err := rc.NodeMgmtClient.CallDrainEndpoint(pod)
 			if err != nil {

--- a/operator/pkg/reconciliation/reconcile_racks.go
+++ b/operator/pkg/reconciliation/reconcile_racks.go
@@ -911,7 +911,7 @@ func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (int, 
 		shouldUpdate := false
 		if isSeed && currentVal != "true" {
 			rc.Recorder.Eventf(rc.Datacenter, corev1.EventTypeNormal, api.LabeledPodAsSeed,
-				"Making pod %s a seed node", pod.Name)
+				"Labeled as seed node pod %s", pod.Name)
 
 			newLabels[api.SeedNodeLabel] = "true"
 			shouldUpdate = true
@@ -919,7 +919,7 @@ func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (int, 
 		// if this pod is starting, we should leave the seed label alone
 		if !isSeed && currentVal == "true" && !starting {
 			rc.Recorder.Eventf(rc.Datacenter, corev1.EventTypeNormal, "UnsetPodAsSeed",
-				"Making pod %s a non-seed node", pod.Name)
+				"Unlabled as seed node pod %s", pod.Name)
 
 			delete(newLabels, api.SeedNodeLabel)
 			shouldUpdate = true
@@ -1410,7 +1410,7 @@ func (rc *ReconciliationContext) startOneNodePerRack(endpointData httphelper.Cas
 					}
 
 					rc.Recorder.Eventf(rc.Datacenter, corev1.EventTypeNormal, api.LabeledPodAsSeed,
-						"Making pod %s a seed node", pod.Name)
+						"Labeled pod a seed node %s", pod.Name)
 
 					// sleeping five seconds for DNS paranoia
 					time.Sleep(5 * time.Second)


### PR DESCRIPTION
Here are the event types I added. Looking for feedback on the names to make the naming consistent:

```
$ grep Eventf operator/pkg/reconciliation//reconcile_racks.go | grep -oE '["][A-Za-z]+["][,]\s*$' | grep -Eo '[A-Za-z]+'
UpdatingRack
UpateRackLabelsOnResource
StoppingDatacenter
ScaleUpRack
CreateSuperuser
FinishReplaceNode
StartReplaceNode
DeletingStuckPod
SetPodAsSeed
UnsetPodAsSeed
CreatedResource
CreatedResource
UpateRackLabelsOnResource
UpateRackLabelsOnResource
StartedCassandra
StartCassandraAndReplaceNode
StartCassandra
SetPodAsSeed
RestartingCassandra
```