### PR TITLE
Node selector

### DIFF
--- a/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
+++ b/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
@@ -72,6 +72,12 @@ spec:
                   - serverSecretName
                   type: object
               type: object
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: 'A map of label keys and values to restrict Cassandra node
+                scheduling to k8s workers with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+              type: object
             racks:
               description: A list of the named racks in the datacenter, representing
                 independent failure domains. The number of racks should match the

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -144,6 +144,11 @@ type CassandraDatacenterSpec struct {
 	// Whether to do a rolling restart at the next opportunity. The operator will set this back
 	// to false once the restart is in progress.
 	RollingRestartRequested bool `json:"rollingRestartRequested,omitempty"`
+
+	// A map of label keys and values to restrict Cassandra node scheduling to k8s workers
+	// with matchiing labels.
+	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 type StorageConfig struct {

--- a/operator/pkg/apis/cassandra/v1beta1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/cassandra/v1beta1/zz_generated.deepcopy.go
@@ -93,6 +93,13 @@ func (in *CassandraDatacenterSpec) DeepCopyInto(out *CassandraDatacenterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/operator/pkg/apis/cassandra/v1beta1/zz_generated.openapi.go
+++ b/operator/pkg/apis/cassandra/v1beta1/zz_generated.openapi.go
@@ -204,6 +204,21 @@ func schema_pkg_apis_cassandra_v1beta1_CassandraDatacenterSpec(ref common.Refere
 							Format:      "",
 						},
 					},
+					"nodeSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A map of label keys and values to restrict Cassandra node scheduling to k8s workers with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"size", "serverVersion", "serverType", "storageConfig", "clusterName"},
 			},

--- a/operator/pkg/reconciliation/constructor.go
+++ b/operator/pkg/reconciliation/constructor.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	"github.com/datastax/cass-operator/operator/pkg/httphelper"
 	"github.com/datastax/cass-operator/operator/pkg/oplabels"
+	"github.com/datastax/cass-operator/operator/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -321,6 +322,11 @@ func newStatefulSetForCassandraDatacenter(
 				},
 			},
 		},
+	}
+
+	// if the dc.Spec has a nodeSelector map, copy it into each sts pod template
+	if len(dc.Spec.NodeSelector) > 0 {
+		template.Spec.NodeSelector = utils.MergeMap(map[string]string{}, dc.Spec.NodeSelector)
 	}
 
 	// workaround for https://cloud.google.com/kubernetes-engine/docs/security-bulletins#may-31-2019


### PR DESCRIPTION
Add a `nodeSelector` to the CassandraDatacenter, so it can be passed down to the pod templates.

closes #40 