### PR TITLE
fix up logic that cleans up test namespaces when ensuring an empty cluster

### DIFF
--- a/mage/kind/lib.go
+++ b/mage/kind/lib.go
@@ -246,7 +246,7 @@ func EnsureEmptyCluster() {
 
 				// if we fail to delete a dc, then we cannot delete the
 				// namespace because k8s will get stuck, so we need
-				// to stop execution  here
+				// to stop execution here
 				mageutil.PanicOnError(err)
 			}
 			kubectl.DeleteByTypeAndName("namespace", name).ExecVPanic()

--- a/mage/kind/lib.go
+++ b/mage/kind/lib.go
@@ -234,7 +234,21 @@ func EnsureEmptyCluster() {
 		name := strings.Fields(row)[0]
 		if strings.HasPrefix(name, "test-") {
 			fmt.Printf("Cleaning up namespace: %s\n", name)
-			_ = kubectl.Delete("cassandradatacenter", "--all").ExecV()
+			// check if any cassdcs exist in the namespace.
+			// kubectl will return an error if the crd has not been
+			// applied first
+			err := kubectl.Get("cassdc").InNamespace(name).ExecV()
+			if err == nil {
+				// safe to perform a delete cassdcs --all at this point
+				err := kubectl.Delete("cassdcs", "--all").
+					InNamespace(name).
+					ExecV()
+
+				// if we fail to delete a dc, then we cannot delete the
+				// namespace because k8s will get stuck, so we need
+				// to stop execution  here
+				mageutil.PanicOnError(err)
+			}
 			kubectl.DeleteByTypeAndName("namespace", name).ExecVPanic()
 		}
 	}


### PR DESCRIPTION
This fix is related to an issue in which namespaces were not safely cleaned up before integ test runs. We were not using the old test namespace whenever deleting `cassdcs`, so there was potential for some to be left over. When this happened, the proceeding namespace deletion call would hang.