### PR TITLE
Change FROM image to Red Hat Universal Base Image (UBI) 8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
+	k8s.io/api v0.0.0-20191121015604-11707872ac1c
 )
 
 replace github.com/datastax/cass-operator/mage => ./mage

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -4,7 +4,11 @@
 ##########
 # "builder" compiles and tests the code
 # This stage name is important to the Cloud Platform CI/CD infrastructure, and should be preserved
-FROM golang:1.13-stretch as builder
+# FROM golang:1.13-stretch as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
+
+RUN microdnf update && rm -rf /var/cache/yum
+RUN microdnf install golang && microdnf clean all
 
 # Disable cgo - this makes static binaries that will work on an Alpine image
 ENV CGO_ENABLED=0
@@ -49,11 +53,13 @@ COPY operator ./operator
 ARG VERSION_STAMP=DEV
 
 # Build any code not touched by tests (the generated client)
-RUN MO_VERSION=${VERSION_STAMP} mage operator:buildGo
+RUN MO_VERSION=${VERSION_STAMP} /go/bin/mage operator:buildGo
 
 # Second stage
 # Produce a smaller image than the one used to build the code
-FROM alpine:3.9
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+RUN microdnf update && microdnf clean all && rm -rf /var/cache/yum
 
 ENV GOPATH=/go
 WORKDIR /go

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -4,13 +4,12 @@
 ##########
 # "builder" compiles and tests the code
 # This stage name is important to the Cloud Platform CI/CD infrastructure, and should be preserved
-# FROM golang:1.13-stretch as builder
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
 
 RUN microdnf update && rm -rf /var/cache/yum
 RUN microdnf install golang && microdnf clean all
 
-# Disable cgo - this makes static binaries that will work on an Alpine image
+# Disable cgo - this makes static binaries
 ENV CGO_ENABLED=0
 ENV GOPROXY=https://proxy.golang.org,https://gocenter.io,direct
 


### PR DESCRIPTION
This PR changes the `FROM` Dockerfile lines to `registry.access.redhat.com/ubi8/ubi-minimal:latest`.

Additionally, adjustments have been made given the shift from the Debian base to Red Hat.