### PR TITLE
remove delete verb from validating webhook

### DIFF
--- a/charts/cass-operator-chart/templates/validatingwebhookconfiguration.yaml
+++ b/charts/cass-operator-chart/templates/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   rules:
   - apiGroups: ["cassandra.datastax.com"]
     apiVersions: ["v1beta1"]
-    operations: ["CREATE", "UPDATE", "DELETE"]
+    operations: ["CREATE", "UPDATE"]
     resources: ["cassandradatacenters"]
     scope: "*"
   clientConfig:

--- a/docs/user/cass-operator-manifests-pre-1.15.yaml
+++ b/docs/user/cass-operator-manifests-pre-1.15.yaml
@@ -553,7 +553,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - cassandradatacenters
     scope: '*'

--- a/docs/user/cass-operator-manifests.yaml
+++ b/docs/user/cass-operator-manifests.yaml
@@ -555,7 +555,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - cassandradatacenters
     scope: '*'

--- a/operator/pkg/apis/cassandra/v1beta1/webhook.go
+++ b/operator/pkg/apis/cassandra/v1beta1/webhook.go
@@ -115,7 +115,7 @@ func ValidateDatacenterFieldChanges(oldDc CassandraDatacenter, newDc CassandraDa
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-cassandradatacenter,mutating=false,failurePolicy=ignore,groups=cassandra.datastax.com,resources=cassandradatacenters,verbs=create;update;delete,versions=v1beta1,name=validate-cassandradatacenter-webhook
+// +kubebuilder:webhook:path=/validate-cassandradatacenter,mutating=false,failurePolicy=ignore,groups=cassandra.datastax.com,resources=cassandradatacenters,verbs=create;update,versions=v1beta1,name=validate-cassandradatacenter-webhook
 var _ webhook.Validator = &CassandraDatacenter{}
 
 func (dc *CassandraDatacenter) ValidateCreate() error {


### PR DESCRIPTION
This appears to fix the webhook decode error whenever deleting cassdcs pre k8 1.15. As we are not actually performing logic on deletes anyway, this gets us past the issue for now.