### PR TITLE
Merge k3d config with default/current kubeconfig

### DIFF
--- a/mage/kubectl/lib.go
+++ b/mage/kubectl/lib.go
@@ -6,11 +6,24 @@ package kubectl
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"regexp"
 	"time"
 
 	shutil "github.com/datastax/cass-operator/mage/sh"
+	mageutil "github.com/datastax/cass-operator/mage/util"
 )
+
+func GetKubeconfig() string {
+	usr, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	//default config
+	defaultConfig := fmt.Sprintf("%s/.kube/config", usr.HomeDir)
+
+	return mageutil.EnvOrDefault("KUBECONFIG", defaultConfig)
+}
 
 func WatchPods() {
 	shutil.RunVPanic("watch", "-n1", "kubectl", "get", "pods")

--- a/mage/kubectl/lib.go
+++ b/mage/kubectl/lib.go
@@ -19,9 +19,7 @@ func GetKubeconfig() string {
 	if err != nil {
 		panic(err)
 	}
-	//default config
 	defaultConfig := fmt.Sprintf("%s/.kube/config", usr.HomeDir)
-
 	return mageutil.EnvOrDefault("KUBECONFIG", defaultConfig)
 }
 


### PR DESCRIPTION
When using k3d, it creates it own separate config file instead of writing to your current one. This change will merge your current (or default) kubeconfig with the k3d one