### PR TITLE
use the PodIP for mgmt api calls

### DIFF
--- a/operator/pkg/httphelper/client.go
+++ b/operator/pkg/httphelper/client.go
@@ -66,11 +66,22 @@ type CassMetadataEndpoints struct {
 	Entity []EndpointState `json:"entity"`
 }
 
-func BuildPodHostFromPod(pod *corev1.Pod) string {
+type NoPodIPError error
+
+func newNoPodIPError(pod *corev1.Pod) NoPodIPError {
+	return fmt.Errorf("pod %s has no IP", pod.Name)
+}
+
+func BuildPodHostFromPod(pod *corev1.Pod) (string, error) {
 	// This function previously returned the dns hostname which includes the StatefulSet's headless service,
 	// which is the datacenter service. There are times though that we want to make a mgmt api call to the pod
 	// before the dns hostnames are available. It is therefore more reliable to simply use the PodIP.
-	return pod.Status.PodIP
+
+	if len(pod.Status.PodIP) == 0 {
+		return "", newNoPodIPError(pod)
+	}
+
+	return pod.Status.PodIP, nil
 }
 
 func GetPodHost(podName, clusterName, dcName, namespace string) string {
@@ -90,9 +101,14 @@ func parseMetadataEndpointsResponseBody(body []byte) (*CassMetadataEndpoints, er
 func (client *NodeMgmtClient) CallMetadataEndpointsEndpoint(pod *corev1.Pod) (CassMetadataEndpoints, error) {
 	client.Log.Info("requesting Cassandra metadata endpoints from Node Management API", "pod", pod.Name)
 
+	podHost, err := BuildPodHostFromPod(pod)
+	if err != nil {
+		return CassMetadataEndpoints{}, err
+	}
+
 	request := nodeMgmtRequest{
 		endpoint: "/api/v0/metadata/endpoints",
-		host:     BuildPodHostFromPod(pod),
+		host:     podHost,
 		method:   http.MethodGet,
 	}
 
@@ -123,12 +139,17 @@ func (client *NodeMgmtClient) CallCreateRoleEndpoint(pod *corev1.Pod, username s
 	postData.Set("can_login", "true")
 	postData.Set("is_superuser", strconv.FormatBool(superuser))
 
+	podHost, err := BuildPodHostFromPod(pod)
+	if err != nil {
+		return err
+	}
+
 	request := nodeMgmtRequest{
 		endpoint: fmt.Sprintf("/api/v0/ops/auth/role?%s", postData.Encode()),
-		host:     BuildPodHostFromPod(pod),
+		host:     podHost,
 		method:   http.MethodPost,
 	}
-	_, err := callNodeMgmtEndpoint(client, request, "")
+	_, err = callNodeMgmtEndpoint(client, request, "")
 	return err
 }
 
@@ -138,13 +159,18 @@ func (client *NodeMgmtClient) CallProbeClusterEndpoint(pod *corev1.Pod, consiste
 		"pod", pod.Name,
 	)
 
+	podHost, err := BuildPodHostFromPod(pod)
+	if err != nil {
+		return err
+	}
+
 	request := nodeMgmtRequest{
 		endpoint: fmt.Sprintf("/api/v0/probes/cluster?consistency_level=%s&rf_per_dc=%d", consistencyLevel, rfPerDc),
-		host:     BuildPodHostFromPod(pod),
+		host:     podHost,
 		method:   http.MethodGet,
 	}
 
-	_, err := callNodeMgmtEndpoint(client, request, "")
+	_, err = callNodeMgmtEndpoint(client, request, "")
 	return err
 }
 
@@ -154,14 +180,19 @@ func (client *NodeMgmtClient) CallDrainEndpoint(pod *corev1.Pod) error {
 		"pod", pod.Name,
 	)
 
+	podHost, err := BuildPodHostFromPod(pod)
+	if err != nil {
+		return err
+	}
+
 	request := nodeMgmtRequest{
 		endpoint: "/api/v0/ops/node/drain",
-		host:     BuildPodHostFromPod(pod),
+		host:     podHost,
 		method:   http.MethodPost,
 		timeout:  time.Minute * 2,
 	}
 
-	_, err := callNodeMgmtEndpoint(client, request, "")
+	_, err = callNodeMgmtEndpoint(client, request, "")
 	return err
 }
 
@@ -188,9 +219,14 @@ func (client *NodeMgmtClient) CallKeyspaceCleanupEndpoint(pod *corev1.Pod, jobs 
 		return err
 	}
 
+	podHost, err := BuildPodHostFromPod(pod)
+	if err != nil {
+		return err
+	}
+
 	request := nodeMgmtRequest{
 		endpoint: "/api/v0/ops/keyspace/cleanup",
-		host:     BuildPodHostFromPod(pod),
+		host:     podHost,
 		method:   http.MethodPost,
 		timeout:  time.Second * 20,
 		body:     body,
@@ -239,13 +275,18 @@ func (client *NodeMgmtClient) CallReloadSeedsEndpoint(pod *corev1.Pod) error {
 		"pod", pod.Name,
 	)
 
+	podHost, err := BuildPodHostFromPod(pod)
+	if err != nil {
+		return err
+	}
+
 	request := nodeMgmtRequest{
 		endpoint: "/api/v0/ops/seeds/reload",
-		host:     BuildPodHostFromPod(pod),
+		host:     podHost,
 		method:   http.MethodPost,
 	}
 
-	_, err := callNodeMgmtEndpoint(client, request, "")
+	_, err = callNodeMgmtEndpoint(client, request, "")
 	return err
 }
 

--- a/operator/pkg/httphelper/client.go
+++ b/operator/pkg/httphelper/client.go
@@ -73,6 +73,12 @@ func BuildPodHostFromPod(pod *corev1.Pod) string {
 	return pod.Status.PodIP
 }
 
+func GetPodHost(podName, clusterName, dcName, namespace string) string {
+	nodeServicePattern := "%s.%s-%s-service.%s"
+
+	return fmt.Sprintf(nodeServicePattern, podName, clusterName, dcName, namespace)
+}
+
 func parseMetadataEndpointsResponseBody(body []byte) (*CassMetadataEndpoints, error) {
 	endpoints := &CassMetadataEndpoints{}
 	if err := json.Unmarshal(body, &endpoints); err != nil {

--- a/operator/pkg/httphelper/client_test.go
+++ b/operator/pkg/httphelper/client_test.go
@@ -29,7 +29,9 @@ func Test_BuildPodHostFromPod(t *testing.T) {
 		},
 	}
 
-	result := BuildPodHostFromPod(pod)
+	result, err := BuildPodHostFromPod(pod)
+	assert.NoError(t, err)
+
 	expected := "1.2.3.4"
 
 	assert.Equal(t, expected, result)

--- a/operator/pkg/httphelper/client_test.go
+++ b/operator/pkg/httphelper/client_test.go
@@ -24,10 +24,13 @@ func Test_BuildPodHostFromPod(t *testing.T) {
 				api.ClusterLabel:    "the-foobar-cluster",
 			},
 		},
+		Status: corev1.PodStatus{
+			PodIP: "1.2.3.4",
+		},
 	}
 
 	result := BuildPodHostFromPod(pod)
-	expected := "pod-foo.the-foobar-cluster-dc-bar-service.somenamespace"
+	expected := "1.2.3.4"
 
 	assert.Equal(t, expected, result)
 }

--- a/operator/pkg/reconciliation/reconcile_racks_test.go
+++ b/operator/pkg/reconciliation/reconcile_racks_test.go
@@ -1218,6 +1218,7 @@ func Test_callPodEndpoint(t *testing.T) {
 	}
 
 	pod := makeReloadTestPod()
+	pod.Status.PodIP = "1.2.3.4"
 
 	if err := client.CallReloadSeedsEndpoint(pod); err != nil {
 		assert.Fail(t, "Should not have returned error")


### PR DESCRIPTION
The `BuildPodHostFromPod` function returns the hostname that is used to make a request to the mgmt api. That hostname is managed by the StatefulSets headless service, which is the datacenter service. 

This does not alway work though because hostnames are not available until pods are ready, and there are times that the operator needs to make mgmt api requests when pods are not ready. I ran into this while working on support for a Reaper sidecar (ticket yet to be created). The Reaper container won't be ready until Cassandra is up and running. In this scenario the only reliable option is to use the pod IP for mgmt api requests.