### PR TITLE
updated operator to work with multiple namespaces

### DIFF
--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -159,7 +159,7 @@ func main() {
 	// More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
 	if strings.Contains(watchNs, ",") {
 		options.Namespace = ""
-		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
+		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNs, ","))
 	}
 
 	// Create a new manager to provide shared dependencies and start components


### PR DESCRIPTION
split the startup into pulling 2 namespaces... `operatorNs` for the namespace the operator is running in, and `watchNs` for the namespaces passed via the `WATCH_NAMESPACE` environment variable.

I've successfully tested this in my development EKS cluster.  I'm able to get the operator to deploy Cassandra datacenters in namespaces outside the operator.