### PR TITLE
condense kubectl spam

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4


### PR DESCRIPTION
When running an integ test, and we detect stdout is going to a terminal, condense duplicate kubectl spam messages down and just list a count of how many times that command has been run so far

```
STEP: checking that no dc pods remain
2020/06/17 15:29:34 exec: kubectl --output=jsonpath={.items} --namespace=test-terminate-cleanup get pods -l cassandra.datastax.com/datacenter=dc2
Rerunning previous command (15)
```