### PR TITLE
bump version of mgmt sidecar to 0.1.5

### DIFF
--- a/buildsettings.yaml
+++ b/buildsettings.yaml
@@ -19,4 +19,4 @@ dev:
   images:
     - datastax/dse-server:6.8.0
     - datastax/cass-config-builder:1.0.0
-    - datastax/cassandra-mgmtapi-3_11_6:v0.1.2
+    - datastax/cassandra-mgmtapi-3_11_6:v0.1.5

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -50,8 +50,8 @@ type ProgressState string
 // In the event that no image is found, an error is returned
 func getImageForServerVersion(server, version string) (string, error) {
 	const (
-		cassandra_3_11_6 = "datastax/cassandra-mgmtapi-3_11_6:v0.1.2"
-		cassandra_4_0_0  = "datastax/cassandra-mgmtapi-4_0_0:v0.1.2"
+		cassandra_3_11_6 = "datastax/cassandra-mgmtapi-3_11_6:v0.1.4"
+		cassandra_4_0_0  = "datastax/cassandra-mgmtapi-4_0_0:v0.1.4"
 		dse_6_8_0        = "datastax/dse-server:6.8.0"
 	)
 	sv := server + "-" + version

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -50,8 +50,8 @@ type ProgressState string
 // In the event that no image is found, an error is returned
 func getImageForServerVersion(server, version string) (string, error) {
 	const (
-		cassandra_3_11_6 = "datastax/cassandra-mgmtapi-3_11_6:v0.1.4"
-		cassandra_4_0_0  = "datastax/cassandra-mgmtapi-4_0_0:v0.1.4"
+		cassandra_3_11_6 = "datastax/cassandra-mgmtapi-3_11_6:v0.1.5"
+		cassandra_4_0_0  = "datastax/cassandra-mgmtapi-4_0_0:v0.1.5"
 		dse_6_8_0        = "datastax/dse-server:6.8.0"
 	)
 	sv := server + "-" + version

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -41,7 +41,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "cassandra",
 				serverVersion: "3.11.6",
 			},
-			want:      "datastax/cassandra-mgmtapi-3_11_6:v0.1.4",
+			want:      "datastax/cassandra-mgmtapi-3_11_6:v0.1.5",
 			errString: "",
 		},
 		{

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -41,7 +41,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "cassandra",
 				serverVersion: "3.11.6",
 			},
-			want:      "datastax/cassandra-mgmtapi-3_11_6:v0.1.2",
+			want:      "datastax/cassandra-mgmtapi-3_11_6:v0.1.4",
 			errString: "",
 		},
 		{

--- a/operator/pkg/reconciliation/constructor.go
+++ b/operator/pkg/reconciliation/constructor.go
@@ -379,7 +379,6 @@ func buildContainers(dc *api.CassandraDatacenter, serverVolumeMounts []corev1.Vo
 		{Name: "MGMT_API_EXPLICIT_START", Value: "true"},
 		// TODO remove this post 1.0
 		{Name: "DSE_MGMT_EXPLICIT_START", Value: "true"},
-		{Name: "IGNORE_DEFAULTS", Value: "true"},
 	}
 
 	ports, err := dc.GetContainerPorts()

--- a/operator/pkg/reconciliation/constructor.go
+++ b/operator/pkg/reconciliation/constructor.go
@@ -379,6 +379,7 @@ func buildContainers(dc *api.CassandraDatacenter, serverVolumeMounts []corev1.Vo
 		{Name: "MGMT_API_EXPLICIT_START", Value: "true"},
 		// TODO remove this post 1.0
 		{Name: "DSE_MGMT_EXPLICIT_START", Value: "true"},
+		{Name: "IGNORE_DEFAULTS", Value: "true"},
 	}
 
 	ports, err := dc.GetContainerPorts()

--- a/tests/testdata/oss-three-rack-three-node-dc.yaml
+++ b/tests/testdata/oss-three-rack-three-node-dc.yaml
@@ -6,7 +6,7 @@ spec:
   clusterName: cluster1
   serverType: cassandra
   serverVersion: "3.11.6"
-  serverImage: datastax/cassandra-mgmtapi-3_11_6:v0.1.2
+  serverImage: datastax/cassandra-mgmtapi-3_11_6:v0.1.5
   configBuilderImage: datastax/cass-config-builder:1.0.0
   managementApiAuth:
     insecure: {}

--- a/tests/testdata/oss-two-rack-six-node-dc.yaml
+++ b/tests/testdata/oss-two-rack-six-node-dc.yaml
@@ -6,7 +6,7 @@ spec:
   clusterName: cluster1
   serverType: cassandra
   serverVersion: "3.11.6"
-  serverImage: datastax/cassandra-mgmtapi-3_11_6:v0.1.2
+  serverImage: datastax/cassandra-mgmtapi-3_11_6:v0.1.5
   configBuilderImage: datastax/cass-config-builder:1.0.0
   managementApiAuth:
     insecure: {}


### PR DESCRIPTION
v0.1.4 includes the fix for the [unix socket and TCP socket driver conflict issue](https://github.com/datastax/management-api-for-apache-cassandra/issues/18).

This fix is needed for #116 among other things.