### PR TITLE
Headless ClusterIP service for additional seeds

### DIFF
--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -479,6 +479,10 @@ func (dc *CassandraDatacenter) GetSeedServiceName() string {
 	return dc.Spec.ClusterName + "-seed-service"
 }
 
+func (dc *CassandraDatacenter) GetAdditionalSeedServiceName(seedIdx int) string {
+	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-service-%s", seedIdx)
+}
+
 func (dc *CassandraDatacenter) GetAllPodsServiceName() string {
 	return dc.Spec.ClusterName + "-" + dc.Name + "-all-pods-service"
 }

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -483,10 +483,6 @@ func (dc *CassandraDatacenter) GetAdditionalSeedsServiceName() string {
 	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-service")
 }
 
-func (dc *CassandraDatacenter) GetAdditionalSeedsEndpointsName() string {
-	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-endpoints")
-}
-
 func (dc *CassandraDatacenter) GetAllPodsServiceName() string {
 	return dc.Spec.ClusterName + "-" + dc.Name + "-all-pods-service"
 }

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -480,7 +480,7 @@ func (dc *CassandraDatacenter) GetSeedServiceName() string {
 }
 
 func (dc *CassandraDatacenter) GetAdditionalSeedServiceName(seedIdx int) string {
-	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-service-%s", seedIdx)
+	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-service-%d", seedIdx)
 }
 
 func (dc *CassandraDatacenter) GetAllPodsServiceName() string {

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -479,8 +479,12 @@ func (dc *CassandraDatacenter) GetSeedServiceName() string {
 	return dc.Spec.ClusterName + "-seed-service"
 }
 
-func (dc *CassandraDatacenter) GetAdditionalSeedServiceName(seedIdx int) string {
-	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-service-%d", seedIdx)
+func (dc *CassandraDatacenter) GetAdditionalSeedsServiceName() string {
+	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-service")
+}
+
+func (dc *CassandraDatacenter) GetAdditionalSeedsEndpointsName() string {
+	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-endpoints")
 }
 
 func (dc *CassandraDatacenter) GetAllPodsServiceName() string {

--- a/operator/pkg/reconciliation/constructor.go
+++ b/operator/pkg/reconciliation/constructor.go
@@ -97,7 +97,7 @@ func newEndpointsForAdditionalSeeds(dc *api.CassandraDatacenter) *corev1.Endpoin
 	labels := dc.GetDatacenterLabels()
 	oplabels.AddManagedByLabel(labels)
 	var endpoints corev1.Endpoints
-	endpoints.ObjectMeta.Name = dc.GetAdditionalSeedsEndpointsName()
+	endpoints.ObjectMeta.Name = dc.GetAdditionalSeedsServiceName()
 	endpoints.ObjectMeta.Namespace = dc.Namespace
 	endpoints.ObjectMeta.Labels = labels
 

--- a/operator/pkg/reconciliation/constructor.go
+++ b/operator/pkg/reconciliation/constructor.go
@@ -75,23 +75,51 @@ func newSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.S
 }
 
 // newAdditionalSeedServiceForCassandraDatacenter creates a headless service owned by the CassandraDatacenter,
-// which covers one additional seed server pod in the datacenter, whether it is ready or not
-func newAdditionalSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter, seedIdx int, seedName string) *corev1.Service {
+// whether the additional seed pods are ready or not
+func newAdditionalSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.Service {
 	labels := dc.GetDatacenterLabels()
 	oplabels.AddManagedByLabel(labels)
-	selector := dc.GetDatacenterLabels()
 	var service corev1.Service
-	service.ObjectMeta.Name = dc.GetAdditionalSeedServiceName(seedIdx)
+	service.ObjectMeta.Name = dc.GetAdditionalSeedsServiceName()
 	service.ObjectMeta.Namespace = dc.Namespace
 	service.ObjectMeta.Labels = labels
-	service.Spec.Selector = selector
-	service.Spec.Type = "ExternalName"
-	service.Spec.ExternalName = seedName
+	// We omit the label selector because we will create the endpoints manually
+	service.Spec.Type = "ClusterIP"
+	service.Spec.ClusterIP = "None"
 	service.Spec.PublishNotReadyAddresses = true
 
 	addHashAnnotation(&service)
 
 	return &service
+}
+
+func newEndpointsForAdditionalSeeds(dc *api.CassandraDatacenter) *corev1.Endpoints {
+	labels := dc.GetDatacenterLabels()
+	oplabels.AddManagedByLabel(labels)
+	var endpoints corev1.Endpoints
+	endpoints.ObjectMeta.Name = dc.GetAdditionalSeedsEndpointsName()
+	endpoints.ObjectMeta.Namespace = dc.Namespace
+	endpoints.ObjectMeta.Labels = labels
+
+	var addresses []corev1.EndpointAddress
+
+	for seedIdx := range dc.Spec.AdditionalSeeds {
+		additionalSeed := dc.Spec.AdditionalSeeds[seedIdx]
+		addresses = append(addresses, corev1.EndpointAddress{
+			IP: additionalSeed,
+		})
+	}
+
+	// See: https://godoc.org/k8s.io/api/core/v1#Endpoints
+	endpoints.Subsets = []corev1.EndpointSubset{
+		{
+			Addresses: addresses,
+		},
+	}
+
+	addHashAnnotation(&endpoints)
+
+	return &endpoints
 }
 
 // newAllPodsServiceForCassandraDatacenter creates a headless service owned by the CassandraDatacenter,

--- a/operator/pkg/reconciliation/constructor.go
+++ b/operator/pkg/reconciliation/constructor.go
@@ -74,6 +74,26 @@ func newSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.S
 	return service
 }
 
+// newAdditionalSeedServiceForCassandraDatacenter creates a headless service owned by the CassandraDatacenter,
+// which covers one additional seed server pod in the datacenter, whether it is ready or not
+func newAdditionalSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter, seedIdx int, seedName string) *corev1.Service {
+	labels := dc.GetDatacenterLabels()
+	oplabels.AddManagedByLabel(labels)
+	selector := dc.GetDatacenterLabels()
+	var service corev1.Service
+	service.ObjectMeta.Name = dc.GetAdditionalSeedServiceName(seedIdx)
+	service.ObjectMeta.Namespace = dc.Namespace
+	service.ObjectMeta.Labels = labels
+	service.Spec.Selector = selector
+	service.Spec.Type = "ExternalName"
+	service.Spec.ExternalName = seedName
+	service.Spec.PublishNotReadyAddresses = true
+
+	addHashAnnotation(&service)
+
+	return &service
+}
+
 // newAllPodsServiceForCassandraDatacenter creates a headless service owned by the CassandraDatacenter,
 // which covers all server pods in the datacenter, whether they are ready or not
 func newAllPodsServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.Service {

--- a/operator/pkg/reconciliation/context.go
+++ b/operator/pkg/reconciliation/context.go
@@ -39,6 +39,7 @@ type ReconciliationContext struct {
 	Ctx context.Context
 
 	Services               []*corev1.Service
+	Endpoints              *corev1.Endpoints
 	desiredRackInformation []*RackInformation
 	statefulSets           []*appsv1.StatefulSet
 	dcPods                 []*corev1.Pod

--- a/operator/pkg/reconciliation/handler.go
+++ b/operator/pkg/reconciliation/handler.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/datastax/cass-operator/operator/internal/result"
 	api "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
-	"github.com/datastax/cass-operator/operator/pkg/httphelper"
 	"github.com/datastax/cass-operator/operator/pkg/dynamicwatch"
+	"github.com/datastax/cass-operator/operator/pkg/httphelper"
 )
 
 // Use a var so we can mock this function
@@ -48,6 +48,10 @@ func (rc *ReconciliationContext) calculateReconciliationActions() (reconcile.Res
 		return result.Output()
 	}
 
+	if result := rc.CheckAdditionalSeedEndpoints(); result.Completed() {
+		return result.Output()
+	}
+
 	if err := rc.CalculateRackInformation(); err != nil {
 		return result.Error(err).Output()
 	}
@@ -69,12 +73,12 @@ var log = logf.Log.WithName("reconciliation_handler")
 type ReconcileCassandraDatacenter struct {
 	// This client, initialized using mgr.client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client        client.Client
-	scheme        *runtime.Scheme
-	recorder      record.EventRecorder
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
 
 	// SecretWatches is used in the controller when setting up the watches and
-	// during reconciliation where we update the mappings for the watches. 
+	// during reconciliation where we update the mappings for the watches.
 	// Putting it here allows us to get it to both places.
 	SecretWatches dynamicwatch.DynamicWatches
 }

--- a/operator/pkg/reconciliation/reconcile_endpoints.go
+++ b/operator/pkg/reconciliation/reconcile_endpoints.go
@@ -49,8 +49,6 @@ func (rc *ReconciliationContext) CheckAdditionalSeedEndpoints() result.Reconcile
 
 	logger.Info("reconcile_endpoints::CheckAdditionalSeedEndpoints")
 
-	// Check if there is a headless service for the cluster
-
 	desiredEndpoints := newEndpointsForAdditionalSeeds(dc)
 
 	createNeeded := false

--- a/operator/pkg/reconciliation/reconcile_endpoints.go
+++ b/operator/pkg/reconciliation/reconcile_endpoints.go
@@ -36,8 +36,6 @@ func (rc *ReconciliationContext) CreateEndpointsForAdditionalSeedService() resul
 
 	rc.Recorder.Eventf(rc.Datacenter, "Normal", "CreatedResource", "Created endpoints %s", endpoints.Name)
 
-	// at this point we had previously been saying this reconcile call was over, we're done
-	// but that seems wrong, we should just continue on to the next resources
 	return result.Continue()
 }
 

--- a/operator/pkg/reconciliation/reconcile_endpoints.go
+++ b/operator/pkg/reconciliation/reconcile_endpoints.go
@@ -103,7 +103,7 @@ func (rc *ReconciliationContext) CheckAdditionalSeedEndpoints() result.Reconcile
 	}
 
 	if createNeeded {
-		rc.Endpoints = &desiredEndpoints
+		rc.Endpoints = desiredEndpoints
 		return rc.CreateEndpointsForAdditionalSeedService()
 	}
 

--- a/operator/pkg/reconciliation/reconcile_endpoints.go
+++ b/operator/pkg/reconciliation/reconcile_endpoints.go
@@ -47,6 +47,10 @@ func (rc *ReconciliationContext) CheckAdditionalSeedEndpoints() result.Reconcile
 
 	logger.Info("reconcile_endpoints::CheckAdditionalSeedEndpoints")
 
+	if len(dc.Spec.AdditionalSeeds) == 0 {
+		return result.Continue()
+	}
+
 	desiredEndpoints := newEndpointsForAdditionalSeeds(dc)
 
 	createNeeded := false

--- a/operator/pkg/reconciliation/reconcile_endpoints.go
+++ b/operator/pkg/reconciliation/reconcile_endpoints.go
@@ -1,0 +1,111 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package reconciliation
+
+import (
+	"github.com/datastax/cass-operator/operator/internal/result"
+	api "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/datastax/cass-operator/operator/pkg/utils"
+)
+
+func (rc *ReconciliationContext) CreateEndpointsForAdditionalSeedService() result.ReconcileResult {
+	// unpacking
+	logger := rc.ReqLogger
+	client := rc.Client
+	endpoints := rc.Endpoints
+
+	logger.Info(
+		"Creating endpoints for additional seed service",
+		"endpointsNamespace", endpoints.Namespace,
+		"endpointsName", endpoints.Name)
+
+	if err := setOperatorProgressStatus(rc, api.ProgressUpdating); err != nil {
+		return result.Error(err)
+	}
+
+	if err := client.Create(rc.Ctx, endpoints); err != nil {
+		logger.Error(err, "Could not create endpoints for additional seed service")
+
+		return result.Error(err)
+	}
+
+	rc.Recorder.Eventf(rc.Datacenter, "Normal", "CreatedResource", "Created endpoints %s", endpoints.Name)
+
+	// at this point we had previously been saying this reconcile call was over, we're done
+	// but that seems wrong, we should just continue on to the next resources
+	return result.Continue()
+}
+
+func (rc *ReconciliationContext) CheckAdditionalSeedEndpoints() result.ReconcileResult {
+	// unpacking
+	logger := rc.ReqLogger
+	dc := rc.Datacenter
+	client := rc.Client
+
+	logger.Info("reconcile_endpoints::CheckAdditionalSeedEndpoints")
+
+	// Check if there is a headless service for the cluster
+
+	desiredEndpoints := newEndpointsForAdditionalSeeds(dc)
+
+	createNeeded := false
+
+	// Set CassandraDatacenter dc as the owner and controller
+	err := setControllerReference(dc, desiredEndpoints, rc.Scheme)
+	if err != nil {
+		logger.Error(err, "Could not set controller reference for endpoints for additional seed service")
+		return result.Error(err)
+	}
+
+	// See if the Endpoints already exists
+	nsName := types.NamespacedName{Name: desiredEndpoints.Name, Namespace: desiredEndpoints.Namespace}
+	currentEndpoints := &corev1.Endpoints{}
+	err = client.Get(rc.Ctx, nsName, currentEndpoints)
+
+	if err != nil && errors.IsNotFound(err) {
+		// if it's not found, we need to create it
+		createNeeded = true
+
+	} else if err != nil {
+		// if we hit a k8s error, log it and error out
+		logger.Error(err, "Could not get endoints for additional seed service",
+			"name", nsName,
+		)
+		return result.Error(err)
+
+	} else {
+		// if we found the endpoints already, check if it needs updating
+		if !resourcesHaveSameHash(currentEndpoints, desiredEndpoints) {
+			resourceVersion := currentEndpoints.GetResourceVersion()
+			// preserve any labels and annotations that were added to the Endpoints post-creation
+			desiredEndpoints.Labels = utils.MergeMap(map[string]string{}, currentEndpoints.Labels, desiredEndpoints.Labels)
+			desiredEndpoints.Annotations = utils.MergeMap(map[string]string{}, currentEndpoints.Annotations, desiredEndpoints.Annotations)
+
+			logger.Info("Updating endpoints for additional seed service",
+				"endpoints", currentEndpoints,
+				"desired", desiredEndpoints)
+
+			desiredEndpoints.DeepCopyInto(currentEndpoints)
+
+			currentEndpoints.SetResourceVersion(resourceVersion)
+
+			if err := client.Update(rc.Ctx, currentEndpoints); err != nil {
+				logger.Error(err, "Unable to update endpoints for additional seed service",
+					"endpoints", currentEndpoints)
+				return result.Error(err)
+			}
+		}
+	}
+
+	if createNeeded {
+		rc.Endpoints = &desiredEndpoints
+		return rc.CreateEndpointsForAdditionalSeedService()
+	}
+
+	return result.Continue()
+}

--- a/operator/pkg/reconciliation/reconcile_services.go
+++ b/operator/pkg/reconciliation/reconcile_services.go
@@ -61,6 +61,12 @@ func (rc *ReconciliationContext) CheckHeadlessServices() result.ReconcileResult 
 
 	services := []*corev1.Service{cqlService, seedService, allPodsService}
 
+	for seedIdx := range dc.Spec.AdditionalSeeds {
+		additionalSeed := dc.Spec.AdditionalSeeds[seedIdx]
+		additionalSeedService := newAdditionalSeedServiceForCassandraDatacenter(dc, seedIdx, additionalSeed)
+		services = append(services, additionalSeedService)
+	}
+
 	createNeeded := []*corev1.Service{}
 
 	for idx := range services {

--- a/operator/pkg/reconciliation/reconcile_services.go
+++ b/operator/pkg/reconciliation/reconcile_services.go
@@ -61,9 +61,8 @@ func (rc *ReconciliationContext) CheckHeadlessServices() result.ReconcileResult 
 
 	services := []*corev1.Service{cqlService, seedService, allPodsService}
 
-	for seedIdx := range dc.Spec.AdditionalSeeds {
-		additionalSeed := dc.Spec.AdditionalSeeds[seedIdx]
-		additionalSeedService := newAdditionalSeedServiceForCassandraDatacenter(dc, seedIdx, additionalSeed)
+	if len(dc.Spec.AdditionalSeeds) > 0 {
+		additionalSeedService := newAdditionalSeedServiceForCassandraDatacenter(dc)
 		services = append(services, additionalSeedService)
 	}
 

--- a/tests/additional_seeds/additional_seeds_suite_test.go
+++ b/tests/additional_seeds/additional_seeds_suite_test.go
@@ -1,0 +1,289 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package additional_seeds
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	ginkgo_util "github.com/datastax/cass-operator/mage/ginkgo"
+	"github.com/datastax/cass-operator/mage/kubectl"
+)
+
+var (
+	testName     = "Seed Selection"
+	namespace    = "test-additional-seeds"
+	dcName       = "dc1"
+	dcYaml       = "../testdata/additional-seeds-two-rack-four-node-dc.yaml"
+	operatorYaml = "../testdata/operator.yaml"
+	dcResource   = fmt.Sprintf("CassandraDatacenter/%s", dcName)
+	dcLabel      = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)
+	ns           = ginkgo_util.NewWrapper(testName, namespace)
+)
+
+func TestLifecycle(t *testing.T) {
+	AfterSuite(func() {
+		logPath := fmt.Sprintf("%s/aftersuite", ns.LogDir)
+		kubectl.DumpAllLogs(logPath).ExecV()
+
+		fmt.Printf("\n\tPost-run logs dumped at: %s\n\n", logPath)
+		ns.Terminate()
+	})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, testName)
+}
+
+type Node struct {
+	Name    string
+	Rack    string
+	Ready   bool
+	Seed    bool
+	Started bool
+	IP      string
+	Ordinal int
+}
+
+type DatacenterInfo struct {
+	Size      int
+	RackNames []string
+	Nodes     []Node
+}
+
+func retrieveNodes() []Node {
+	k := kubectl.Get("pods").
+		WithLabel(dcLabel).
+		FormatOutput("json")
+	output := ns.OutputPanic(k)
+	data := corev1.PodList{}
+	err := json.Unmarshal([]byte(output), &data)
+	Expect(err).ToNot(HaveOccurred())
+	result := []Node{}
+	for idx, _ := range data.Items {
+		pod := &data.Items[idx]
+		node := Node{}
+		node.Name = pod.Name
+		node.IP = pod.Status.PodIP
+		node.Rack = pod.Labels["cassandra.datastax.com/rack"]
+		isSeed, hasSeedLabel := pod.Labels["cassandra.datastax.com/seed-node"]
+		node.Seed = hasSeedLabel && isSeed == "true"
+		isStarted, hasStartedLabel := pod.Labels["cassandra.datastax.com/node-state"]
+		node.Started = hasStartedLabel && isStarted == "Started"
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == "Ready" {
+				node.Ready = condition.Status == "True"
+			}
+		}
+		result = append(result, node)
+	}
+	return result
+}
+
+func retrieveDatacenterInfo() DatacenterInfo {
+	k := kubectl.Get(dcResource).
+		FormatOutput("json")
+	output := ns.OutputPanic(k)
+	data := map[string]interface{}{}
+	err := json.Unmarshal([]byte(output), &data)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = json.Unmarshal([]byte(output), &data)
+
+	spec := data["spec"].(map[string]interface{})
+	rackNames := []string{}
+	for _, rackData := range spec["racks"].([]interface{}) {
+		name := rackData.(map[string]interface{})["name"]
+		if name != nil {
+			rackNames = append(rackNames, name.(string))
+		}
+	}
+
+	dc := DatacenterInfo{
+		Size:      int(spec["size"].(float64)),
+		Nodes:     retrieveNodes(),
+		RackNames: rackNames,
+	}
+
+	return dc
+}
+
+func retrieveNameSeedNodeForRack(rack string) string {
+	info := retrieveDatacenterInfo()
+	name := ""
+	for _, node := range info.Nodes {
+		if node.Rack == rack && node.Seed {
+			name = node.Name
+			break
+		}
+	}
+
+	Expect(name).ToNot(Equal(""))
+	return name
+}
+
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func checkThereAreAtLeastThreeSeedsPerDc(info DatacenterInfo) {
+	seedCount := 0
+
+	for _, node := range info.Nodes {
+		if node.Seed {
+			seedCount += 1
+		}
+	}
+
+	expectedSeedCount := MinInt(info.Size, 3)
+	Expect(seedCount >= expectedSeedCount).To(BeTrue(),
+		"Expected there to be at least %d seed nodes, but only found %d.",
+		expectedSeedCount, seedCount)
+}
+
+func checkThereIsAtLeastOneSeedNodePerRack(info DatacenterInfo) {
+	rackToFoundSeed := map[string]bool{}
+	for _, node := range info.Nodes {
+		if node.Seed {
+			rackToFoundSeed[node.Rack] = true
+		}
+	}
+
+	for _, rackName := range info.RackNames {
+		value, ok := rackToFoundSeed[rackName]
+		Expect(ok && value).To(BeTrue(), "Expected rack %s to have a seed node, but none found.", rackName)
+	}
+}
+
+func checkDesignatedSeedNodesAreStartedAndReady(info DatacenterInfo) {
+	for _, node := range info.Nodes {
+		if node.Seed {
+			Expect(node.Started).To(BeTrue(), "Expected %s to be labeled as started but was not.", node.Name)
+			Expect(node.Ready).To(BeTrue(), "Expected %s to be ready but was not.", node.Name)
+		}
+	}
+}
+
+func checkCassandraSeedListsAlignWithSeedLabels(info DatacenterInfo) {
+	expectedSeeds := []string{}
+	for _, node := range info.Nodes {
+		if node.Seed {
+			expectedSeeds = append(expectedSeeds, node.IP)
+		}
+	}
+	sort.Strings(expectedSeeds)
+
+	re := regexp.MustCompile(`[0-9]+[.][0-9]+[.][0-9]+[.][0-9]+`)
+	for _, node := range info.Nodes {
+		if node.Ready && node.Started {
+			k := kubectl.ExecOnPod(node.Name, "--", "nodetool", "getseeds")
+			output := ns.OutputPanic(k)
+			seeds := re.FindAllString(output, -1)
+			if node.Seed {
+				seeds = append(seeds, node.IP)
+			}
+			sort.Strings(seeds)
+
+			Expect(seeds).To(Equal(expectedSeeds), "Expected pod %s to have seeds %v but had %v", node.Name, expectedSeeds, seeds)
+		}
+	}
+}
+
+func checkSeedConstraints() {
+	info := retrieveDatacenterInfo()
+	// There should be 3 seed nodes for every datacenter
+	checkThereAreAtLeastThreeSeedsPerDc(info)
+
+	// There should be 2 seed nodes per rack
+	// this is because of the additional seeds
+	checkThereIsAtLeastOneSeedNodePerRack(info)
+
+	// Seed nodes should not be down
+	checkDesignatedSeedNodesAreStartedAndReady(info)
+
+	// Ensure seed lists actually align
+	//
+	// NOTE: The following check does not presently work due to
+	// the lag time between when we update a seed label and when
+	// that change is reflected in DNS. Since we reload seed lists
+	// right after upating the label, some cassandra nodes will
+	// likely end up with slight out-of-date seed lists. KO-375
+	//
+	// checkCassandraSeedListsAlignWithSeedLabels(info)
+}
+
+func disableGossipWaitNotReady(podName string) {
+	disableGossip(podName)
+	ns.WaitForPodNotStarted(podName)
+}
+
+func enableGossipWaitReady(podName string) {
+	enableGossip(podName)
+	ns.WaitForPodStarted(podName)
+}
+
+func disableGossip(podName string) {
+	execArgs := []string{"-c", "cassandra",
+		"--", "bash", "-c",
+		"nodetool disablegossip",
+	}
+	k := kubectl.ExecOnPod(podName, execArgs...)
+	ns.ExecVPanic(k)
+}
+
+func enableGossip(podName string) {
+	execArgs := []string{"-c", "cassandra",
+		"--", "bash", "-c",
+		"nodetool enablegossip",
+	}
+	k := kubectl.ExecOnPod(podName, execArgs...)
+	ns.ExecVPanic(k)
+}
+
+var _ = Describe(testName, func() {
+	Context("when in a new cluster", func() {
+		Specify("the operator properly updates seed nodes", func() {
+			var step string
+			var k kubectl.KCmd
+
+			By("creating a namespace")
+			err := kubectl.CreateNamespace(namespace).ExecV()
+			Expect(err).ToNot(HaveOccurred())
+
+			step = "setting up cass-operator resources via helm chart"
+			ns.HelmInstall("../../charts/cass-operator-chart")
+
+			ns.WaitForOperatorReady()
+
+			step = "creating a datacenter resource with 2 racks/4 nodes and 2 additional seeds"
+			k = kubectl.ApplyFiles(dcYaml)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterReady(dcName)
+
+			checkSeedConstraints()
+
+			//checkAdditionalSeedService("")
+
+			rack1Seed := retrieveNameSeedNodeForRack("r1")
+			ns.DisableGossipWaitNotReady(rack1Seed)
+
+			checkSeedConstraints()
+
+			ns.EnableGossipWaitReady(rack1Seed)
+
+			checkSeedConstraints()
+		})
+	})
+})

--- a/tests/testdata/additional-seeds-two-rack-four-node-dc.yaml
+++ b/tests/testdata/additional-seeds-two-rack-four-node-dc.yaml
@@ -9,7 +9,7 @@ spec:
   managementApiAuth:
     insecure: {}
   size: 4
-  additionalSeeds: ["cluster1-dc1-r1-sts-1", "cluster1-dc1-r2-sts-1"]
+  additionalSeeds: ["192.168.1.1"]
   storageConfig:
       cassandraDataVolumeClaimSpec:
         storageClassName: server-storage

--- a/tests/testdata/additional-seeds-two-rack-four-node-dc.yaml
+++ b/tests/testdata/additional-seeds-two-rack-four-node-dc.yaml
@@ -8,7 +8,8 @@ spec:
   serverVersion: "6.8.1"
   managementApiAuth:
     insecure: {}
-  size: 3
+  size: 4
+  additionalSeeds: ["cluster1-dc1-r1-sts-1", "cluster1-dc1-r2-sts-1"]
   storageConfig:
       cassandraDataVolumeClaimSpec:
         storageClassName: server-storage
@@ -20,7 +21,6 @@ spec:
   racks:
     - name: r1
     - name: r2
-    - name: r3
   config:
     jvm-server-options:
       initial_heap_size: "800m"

--- a/tests/testdata/default-three-rack-three-node-dc.yaml
+++ b/tests/testdata/default-three-rack-three-node-dc.yaml
@@ -1,0 +1,30 @@
+apiVersion: cassandra.datastax.com/v1beta1
+kind: CassandraDatacenter
+metadata:
+  name: dc1
+spec:
+  clusterName: cluster1
+  serverType: dse
+  serverVersion: "6.8.1"
+  managementApiAuth:
+    insecure: {}
+  size: 3
+  storageConfig:
+      cassandraDataVolumeClaimSpec:
+        storageClassName: server-storage
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  racks:
+    - name: r1
+    - name: r2
+    - name: r3
+  config:
+    jvm-server-options:
+      initial_heap_size: "800m"
+      max_heap_size: "800m"
+    cassandra-yaml:
+      file_cache_size_in_mb: 100
+      memtable_space_in_mb: 100


### PR DESCRIPTION
This adds a headless ClusterIP service for the additional seeds.  The additional seeds must be specified as IP addresses, and not as hostnames.  The additional seeds ip addresses are added to an Endpoints resource.