### PR TITLE
Fix link to sample-cluster-sample-dc.yaml

### DIFF
--- a/docs/ingress/README.md
+++ b/docs/ingress/README.md
@@ -130,7 +130,7 @@ Each of the three reference implementations has a corresponding configuration in
 
 ## Sample `CassandraDatacenter` Reference
 
-See [`sample-cluster-sample-dc.cassdc.yaml`](sample-cluster-sample-dc.cassdc.yaml)
+See [`sample-cluster-sample-dc.yaml`](sample-cluster-sample-dc.cassdc.yaml)
 
 ## SSL Certificate Generation
 

--- a/docs/ingress/README.md
+++ b/docs/ingress/README.md
@@ -130,7 +130,7 @@ Each of the three reference implementations has a corresponding configuration in
 
 ## Sample `CassandraDatacenter` Reference
 
-See [`sample-cluster-sample-dc.yaml`](sample-cluster-sample-dc.cassdc.yaml)
+See [`sample-cluster-sample-dc.yaml`](sample-cluster-sample-dc.yaml)
 
 ## SSL Certificate Generation
 


### PR DESCRIPTION
Prior value was a 404:  sample-cluster-sample-dc.cassdc.yaml