### PR TITLE
Pvc taint handling v2

### DIFF
--- a/mage/kubectl/lib.go
+++ b/mage/kubectl/lib.go
@@ -142,6 +142,11 @@ func Taint(node string, key string, value string, effect string) KCmd {
 	return KCmd{Command: "taint", Args: args}
 }
 
+func Annotate(resource string, name string, key string, value string) KCmd {
+	args := []string{resource, name, fmt.Sprintf("%s=%s", key, value)}
+	return KCmd{Command: "annotate", Args: args}
+}
+
 func CreateFromFiles(paths ...string) KCmd {
 	var args []string
 	for _, p := range paths {

--- a/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
+++ b/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
@@ -18,7 +18,6 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/datastax/cass-operator/operator/pkg/oplabels"
 	"github.com/datastax/cass-operator/operator/pkg/reconciliation"
 	corev1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"

--- a/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
+++ b/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
@@ -122,7 +122,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Setup watches for Nodes to check for taints being added
 
-	mapFn := handler.ToRequestsFunc(
+	nodeMapFn := handler.ToRequestsFunc(
 		func(a handler.MapObject) []reconcile.Request {
 			log.Info("Node Watch called")
 			requests := []reconcile.Request{}
@@ -150,7 +150,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		err = c.Watch(
 			&source.Kind{Type: &corev1.Node{}},
 			&handler.EnqueueRequestsFromMapFunc{
-				ToRequests: mapFn,
+				ToRequests: nodeMapFn,
 			},
 		)
 		if err != nil {

--- a/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
+++ b/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
@@ -51,7 +51,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	err = c.Watch(
 		&source.Kind{Type: &api.CassandraDatacenter{}},
 		&handler.EnqueueRequestForObject{},
-		// This allows us to update the status on every reconcile call without 
+		// This allows us to update the status on every reconcile call without
 		// triggering an infinite loop.
 		predicate.GenerationChangedPredicate{})
 	if err != nil {
@@ -165,22 +165,23 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			log.Info("PersistentVolumeClaim Watch called")
 			requests := []reconcile.Request{}
 
-			pvcName := a.Object.(*corev1.PersistentVolumeClaim).Name
-			dcs := reconciliation.DatacentersForPvc(pvcName)
+			pvc := a.Object.(*corev1.PersistentVolumeClaim)
+			pvcLabels := pvc.ObjectMeta.Labels
+			pvcNamespace := pvc.ObjectMeta.Namespace
 
-			for _, dc := range dcs {
-				log.Info("PersistentVolumeClaim watch adding reconcilation request",
-					"cassandraDatacenter", dc.Name,
-					"namespace", dc.Namespace)
+			dcName := pvcLabels[api.DatacenterLabel]
 
-				// Create reconcilerequests for the related cassandraDatacenter
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      dc.Name,
-						Namespace: dc.Namespace,
-					}},
-				)
-			}
+			log.Info("PersistentVolumeClaim watch adding reconcilation request",
+				"cassandraDatacenter", dcName,
+				"namespace", pvcNamespace)
+
+			// Create reconcilerequests for the related cassandraDatacenter
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      dcName,
+					Namespace: pvcNamespace,
+				}},
+			)
 			return requests
 		})
 

--- a/operator/pkg/reconciliation/check_nodes.go
+++ b/operator/pkg/reconciliation/check_nodes.go
@@ -105,7 +105,7 @@ func (rc *ReconciliationContext) DeletePvcIgnoreFinalizers(podNamespace string, 
 }
 
 // Check nodes for vmware PSP draining taints
-// and check PVCs for vmware PSP failure taints
+// and check PVCs for vmware PSP failure annotations
 func (rc *ReconciliationContext) checkNodeAndPvcTaints() error {
 	logger := rc.ReqLogger
 	rc.ReqLogger.Info("reconciler::checkNodesTaints")

--- a/operator/pkg/reconciliation/reconcile_datacenter.go
+++ b/operator/pkg/reconciliation/reconcile_datacenter.go
@@ -44,10 +44,6 @@ func (rc *ReconciliationContext) ProcessDeletion() result.ReconcileResult {
 		rc.RemoveDcFromNodeToDcMap(types.NamespacedName{
 			Name:      rc.Datacenter.GetName(),
 			Namespace: rc.Datacenter.GetNamespace()})
-
-		rc.RemoveDcFromPvcToDcMap(types.NamespacedName{
-			Name:      rc.Datacenter.GetName(),
-			Namespace: rc.Datacenter.GetNamespace()})
 	}
 
 	// Update finalizer to allow delete of CassandraDatacenter

--- a/operator/pkg/reconciliation/reconcile_datacenter.go
+++ b/operator/pkg/reconciliation/reconcile_datacenter.go
@@ -44,6 +44,10 @@ func (rc *ReconciliationContext) ProcessDeletion() result.ReconcileResult {
 		rc.RemoveDcFromNodeToDcMap(types.NamespacedName{
 			Name:      rc.Datacenter.GetName(),
 			Namespace: rc.Datacenter.GetNamespace()})
+
+		rc.RemoveDcFromPvcToDcMap(types.NamespacedName{
+			Name:      rc.Datacenter.GetName(),
+			Namespace: rc.Datacenter.GetNamespace()})
 	}
 
 	// Update finalizer to allow delete of CassandraDatacenter

--- a/operator/pkg/reconciliation/reconcile_racks.go
+++ b/operator/pkg/reconciliation/reconcile_racks.go
@@ -2141,10 +2141,11 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return result.Error(err).Output()
 	}
 
-	// We do the node taint check here, with the assumption that the cluster is "healthy"
+	// We do the node and pvc taint checks here
+	// with the assumption that the cluster is healthy
 
 	if utils.IsPSPEnabled() {
-		if err := rc.checkNodeTaints(); err != nil {
+		if err := rc.checkNodeAndPvcTaints(); err != nil {
 			return result.Error(err).Output()
 		}
 	}

--- a/tests/psp_pvc_annotation/psp_pvc_annotation_suite_test.go
+++ b/tests/psp_pvc_annotation/psp_pvc_annotation_suite_test.go
@@ -1,0 +1,120 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package psp_pvc_annotation
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ginkgo_util "github.com/datastax/cass-operator/mage/ginkgo"
+	"github.com/datastax/cass-operator/mage/kubectl"
+)
+
+var (
+	testName    = "Tolerations"
+	opNamespace = "test-tolerations"
+	dc1Name     = "dc1"
+	// This scenario requires RF greater than 2
+	dc1Yaml      = "../testdata/tolerations-dc.yaml"
+	dc1Resource  = fmt.Sprintf("CassandraDatacenter/%s", dc1Name)
+	pod1Name     = "cluster1-dc1-r1-sts-0"
+	pod1Resource = fmt.Sprintf("pod/%s", pod1Name)
+	ns           = ginkgo_util.NewWrapper(testName, opNamespace)
+)
+
+func TestLifecycle(t *testing.T) {
+	AfterSuite(func() {
+		logPath := fmt.Sprintf("%s/aftersuite", ns.LogDir)
+		err := kubectl.DumpAllLogs(logPath).ExecV()
+		if err != nil {
+			fmt.Printf("\n\tError during dumping logs: %s\n\n", err.Error())
+		}
+		fmt.Printf("\n\tPost-run logs dumped at: %s\n\n", logPath)
+		ns.Terminate()
+	})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, testName)
+}
+
+var _ = Describe(testName, func() {
+	Context("when in a new cluster", func() {
+		Specify("the operator can build pods with tolerations", func() {
+
+			By("creating a namespace for the cass-operator")
+			err := kubectl.CreateNamespace(opNamespace).ExecV()
+			Expect(err).ToNot(HaveOccurred())
+
+			step := "setting up cass-operator resources via helm chart"
+			ns.HelmInstallWithPSPEnabled("../../charts/cass-operator-chart")
+
+			ns.WaitForOperatorReady()
+
+			step = "creating first datacenter resource"
+			k := kubectl.ApplyFiles(dc1Yaml)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterReady(dc1Name)
+
+			// Add a taint to the node for the first pod
+
+			k = kubectl.GetNodeNameForPod(pod1Name)
+			node1Name, _, err := ns.ExecVCapture(k)
+			if err != nil {
+				panic(err)
+			}
+
+			node1Resource := fmt.Sprintf("node/%s", node1Name)
+
+			// Cleanup: Remove the taint
+			defer func() {
+				json := `
+						{
+							"spec": {
+								"taints": null
+							}
+						}`
+				k = kubectl.PatchMerge(node1Resource, json)
+				err = k.ExecV()
+				if err != nil {
+					panic(err)
+				}
+			}()
+
+			// node.vmware.com/drain=planned-downtime:NoSchedule
+			step = fmt.Sprintf("tainting node: %s", node1Name)
+			k = kubectl.Taint(
+				node1Name,
+				"node.vmware.com/drain",
+				"planned-downtime",
+				"NoSchedule")
+			ns.ExecAndLog(step, k)
+
+			// Wait for a pod to no longer be ready
+
+			i := 1
+			for i < 300 {
+				time.Sleep(1 * time.Second)
+				i += 1
+
+				names := ns.GetDatacenterReadyPodNames(dc1Name)
+				if len(names) < 2 {
+					break
+				}
+			}
+
+			// In my environment, I have to add a wait here
+
+			time.Sleep(1 * time.Minute)
+
+			// Wait for the cluster to heal itself
+
+			ns.WaitForDatacenterReady(dc1Name)
+		})
+	})
+})

--- a/tests/psp_pvc_annotation/psp_pvc_annotation_suite_test.go
+++ b/tests/psp_pvc_annotation/psp_pvc_annotation_suite_test.go
@@ -88,7 +88,7 @@ var _ = Describe(testName, func() {
 				i += 1
 
 				names := ns.GetDatacenterReadyPodNames(dc1Name)
-				if len(names) < 2 {
+				if len(names) < 3 {
 					break
 				}
 			}

--- a/tests/tolerations/tolerations_suite_test.go
+++ b/tests/tolerations/tolerations_suite_test.go
@@ -45,7 +45,7 @@ func TestLifecycle(t *testing.T) {
 
 var _ = Describe(testName, func() {
 	Context("when in a new cluster", func() {
-		Specify("the operator can build pods with tolerations", func() {
+		Specify("the operator can respond to PSP node taints", func() {
 
 			By("creating a namespace for the cass-operator")
 			err := kubectl.CreateNamespace(opNamespace).ExecV()


### PR DESCRIPTION
This PR adds a watch for PersistentVolumeClaims and if an annotation of the form:

volumehealth.storage.kubernetes.io/health:inaccessible

then the operator will terminate the pvc and the corresponding pod.  The corresponding statefulset will then recreate them.