### PR TITLE
default to kind

### DIFF
--- a/mage/k8s/lib.go
+++ b/mage/k8s/lib.go
@@ -77,7 +77,8 @@ func cleanupLingeringHelmResources() {
 
 func loadClusterSettings() {
 	if clusterType == "" {
-		clusterType = mageutil.EnvOrDefault(envK8sFlavor, "k3d")
+        // Default to kind because it is more reliable
+		clusterType = mageutil.EnvOrDefault(envK8sFlavor, "kind")
 	}
 
 	if clusterActions == nil {

--- a/mage/k8s/lib.go
+++ b/mage/k8s/lib.go
@@ -77,7 +77,7 @@ func cleanupLingeringHelmResources() {
 
 func loadClusterSettings() {
 	if clusterType == "" {
-        // Default to kind because it is more reliable
+		// Default to kind because it is more reliable
 		clusterType = mageutil.EnvOrDefault(envK8sFlavor, "kind")
 	}
 


### PR DESCRIPTION
Default the integration tests to kind instead of k3d, because kind is more reliable, even though it is more resource hungry.  

If the user can ensure that k3d is properly functional, they can override the default k8s flavor using an environment variable.