### PR TITLE
Filter node changes to only taint changes

### DIFF
--- a/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
+++ b/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
@@ -164,7 +164,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				return true
 			}
 
-			return !utils.DeepEqualArrayIgnoreOrder(
+			return !utils.ElementsMatch(
 				nodeOld.Spec.Taints, nodeNew.Spec.Taints)
 		},
 	}

--- a/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
+++ b/operator/pkg/controller/cassandradatacenter/cassandradatacenter_controller.go
@@ -146,12 +146,36 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			return requests
 		})
 
+	nodeTaintsChangedPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			nodeOld, ok1 := e.ObjectOld.(*corev1.Node)
+			nodeNew, ok2 := e.ObjectNew.(*corev1.Node)
+
+			if !ok1 || !ok2 {
+				log.Error(nil, "Failed to cast update.Event objects to type Node", "objectOld", e.ObjectOld, "objectNew", e.ObjectNew)
+				return true
+			}
+
+			if nodeOld == nil && nodeNew == nil {
+				return false
+			}
+
+			if (nodeOld == nil && nodeNew != nil) || (nodeOld != nil && nodeNew == nil) {
+				return true
+			}
+
+			return !utils.DeepEqualArrayIgnoreOrder(
+				nodeOld.Spec.Taints, nodeNew.Spec.Taints)
+		},
+	}
+
 	if utils.IsPSPEnabled() {
 		err = c.Watch(
 			&source.Kind{Type: &corev1.Node{}},
 			&handler.EnqueueRequestsFromMapFunc{
 				ToRequests: nodeMapFn,
 			},
+			nodeTaintsChangedPredicate,
 		)
 		if err != nil {
 			return err

--- a/operator/pkg/utils/utilities.go
+++ b/operator/pkg/utils/utilities.go
@@ -30,7 +30,7 @@ func isArrayOrSlice(a interface{}) bool {
 	return k == reflect.Slice || k == reflect.Array
 }
 
-func DeepEqualArrayIgnoreOrder(a interface{}, b interface{}) bool {
+func ElementsMatch(a interface{}, b interface{}) bool {
 	if !isArrayOrSlice(a) || !isArrayOrSlice(b) {
 		return false
 	}

--- a/operator/pkg/utils/utilities_test.go
+++ b/operator/pkg/utils/utilities_test.go
@@ -21,39 +21,39 @@ type foo struct {
 	b int
 }
 
-func Test_DeepEqualArrayIgnoreOrder(t *testing.T) {
+func Test_ElementsMatch(t *testing.T) {
 	var aNil []int = nil
 	var bNil []int = nil
 
-	assert.True(t, DeepEqualArrayIgnoreOrder(
+	assert.True(t, ElementsMatch(
 		[]foo{{1,2}, {3,4}, {5,6}},
 		[]foo{{1,2}, {3,4}, {5,6}}))
 
-	assert.True(t, DeepEqualArrayIgnoreOrder(
+	assert.True(t, ElementsMatch(
 		[]foo{{1,2}, {3,4}, {5,6}},
 		[]foo{{5,6}, {1,2}, {3,4}}))
 
-	assert.True(t, DeepEqualArrayIgnoreOrder(
+	assert.True(t, ElementsMatch(
 		aNil,
 		bNil))
 
-	assert.False(t, DeepEqualArrayIgnoreOrder(
+	assert.False(t, ElementsMatch(
 		[]foo{{1,2}, {3,4}, {5,6}},
 		[]foo{{5,6}, {1,2}}))
 
-	assert.False(t, DeepEqualArrayIgnoreOrder(
+	assert.False(t, ElementsMatch(
 		[]foo{{1,2}, {1,2}},
 		[]foo{{5,6}, {1,2}}))
 
-	assert.False(t, DeepEqualArrayIgnoreOrder(
+	assert.False(t, ElementsMatch(
 		[]foo{{5,6}, {1,2}},
 		[]foo{{1,2}, {1,2}}))
 
-	assert.False(t, DeepEqualArrayIgnoreOrder(
+	assert.False(t, ElementsMatch(
 		aNil,
 		[]foo{{1,2}, {1,2}}))
 
-	assert.False(t, DeepEqualArrayIgnoreOrder(
+	assert.False(t, ElementsMatch(
 		[]foo{{5,6}, {1,2}},
 		bNil))
 }

--- a/operator/pkg/utils/utilities_test.go
+++ b/operator/pkg/utils/utilities_test.go
@@ -6,7 +6,57 @@ package utils
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func test_RangeInt(t *testing.T) {
+	assert.Equal(t, []int{0, 2, 4, 6, 8}, RangeInt(0, 10, 2))
+	assert.Equal(t, []int{0, 1, 2, 3, 4}, RangeInt(0, 5, 1))
+	assert.Equal(t, []int{5, 8}, RangeInt(5, 10, 3))
+}
+
+type foo struct {
+	a int
+	b int
+}
+
+func Test_DeepEqualArrayIgnoreOrder(t *testing.T) {
+	var aNil []int = nil
+	var bNil []int = nil
+
+	assert.True(t, DeepEqualArrayIgnoreOrder(
+		[]foo{{1,2}, {3,4}, {5,6}},
+		[]foo{{1,2}, {3,4}, {5,6}}))
+
+	assert.True(t, DeepEqualArrayIgnoreOrder(
+		[]foo{{1,2}, {3,4}, {5,6}},
+		[]foo{{5,6}, {1,2}, {3,4}}))
+
+	assert.True(t, DeepEqualArrayIgnoreOrder(
+		aNil,
+		bNil))
+
+	assert.False(t, DeepEqualArrayIgnoreOrder(
+		[]foo{{1,2}, {3,4}, {5,6}},
+		[]foo{{5,6}, {1,2}}))
+
+	assert.False(t, DeepEqualArrayIgnoreOrder(
+		[]foo{{1,2}, {1,2}},
+		[]foo{{5,6}, {1,2}}))
+
+	assert.False(t, DeepEqualArrayIgnoreOrder(
+		[]foo{{5,6}, {1,2}},
+		[]foo{{1,2}, {1,2}}))
+
+	assert.False(t, DeepEqualArrayIgnoreOrder(
+		aNil,
+		[]foo{{1,2}, {1,2}}))
+
+	assert.False(t, DeepEqualArrayIgnoreOrder(
+		[]foo{{5,6}, {1,2}},
+		bNil))
+}
 
 func Test_mergeMap(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
To reduce calls to reconcile, only trigger reconcile for node changes that
result from a change of the taints on that node.