### PR TITLE
Setup securitycontext for cassandra

### DIFF
--- a/operator/pkg/reconciliation/construct_statefulset.go
+++ b/operator/pkg/reconciliation/construct_statefulset.go
@@ -125,13 +125,11 @@ func newStatefulSetForCassandraDatacenterHelper(
 	}
 
 	// workaround for https://cloud.google.com/kubernetes-engine/docs/security-bulletins#may-31-2019
-	if dc.Spec.ServerType == "dse" {
-		var userID int64 = 999
-		template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser:  &userID,
-			RunAsGroup: &userID,
-			FSGroup:    &userID,
-		}
+	var userID int64 = 999
+	template.Spec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsUser:  &userID,
+		RunAsGroup: &userID,
+		FSGroup:    &userID,
 	}
 
 	_ = httphelper.AddManagementApiServerSecurity(dc, template)


### PR DESCRIPTION
This sets up the SecurityContext for Cassandra in the same way that it was set up for DSE.  This is related to: 

https://github.com/datastax/management-api-for-apache-cassandra/pull/43