### PR TITLE
Added label to all-pods service to narrow metrics scrape selection

### DIFF
--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -34,6 +34,9 @@ const (
 	// RackLabel is the operator's label for the rack name
 	CassOperatorProgressLabel = "cassandra.datastax.com/operator-progress"
 
+	// PromMetricsLabel is a service label that can be selected for prometheus metrics scraping
+	PromMetricsLabel = "cassandra.datastax.com/prom-metrics"
+
 	// CassNodeState
 	CassNodeState = "cassandra.datastax.com/node-state"
 

--- a/operator/pkg/reconciliation/construct_service.go
+++ b/operator/pkg/reconciliation/construct_service.go
@@ -155,6 +155,7 @@ func newNodePortServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *core
 func newAllPodsServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.Service {
 	service := makeGenericHeadlessService(dc)
 	service.ObjectMeta.Name = dc.GetAllPodsServiceName()
+	service.ObjectMeta.Labels[api.PromMetricsLabel] = "true"
 	service.Spec.PublishNotReadyAddresses = true
 
 	nativePort := api.DefaultNativePort

--- a/operator/pkg/reconciliation/construct_service_test.go
+++ b/operator/pkg/reconciliation/construct_service_test.go
@@ -4,6 +4,8 @@
 package reconciliation
 
 import (
+	"github.com/datastax/cass-operator/operator/pkg/oplabels"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
 
@@ -25,5 +27,29 @@ func TestCassandraDatacenter_buildLabelSelectorForSeedService(t *testing.T) {
 
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("buildLabelSelectorForSeedService = %v, want %v", got, want)
+	}
+}
+
+func TestCassandraDatacenter_allPodsServiceLabels(t *testing.T) {
+	dc := &api.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dc1",
+		},
+		Spec: api.CassandraDatacenterSpec{
+			ClusterName: "bob",
+		},
+	}
+	wantLabels := map[string]string{
+		oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+		api.ClusterLabel:        "bob",
+		api.DatacenterLabel:     "dc1",
+		api.PromMetricsLabel:    "true",
+	}
+
+	service := newAllPodsServiceForCassandraDatacenter(dc)
+
+	gotLabels := service.ObjectMeta.Labels
+	if !reflect.DeepEqual(wantLabels, gotLabels) {
+		t.Errorf("allPodsService labels = %v, want %v", gotLabels, wantLabels)
 	}
 }


### PR DESCRIPTION
This change adds a label `cassandra.datastax.com/prom-metrics: true` to the `{cluster}-{dc}-all-pods-service` in order to narrow the service selector in the [Prometheus operator's ServiceMonitorSpec](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec). Prior to this change both of the services in the following listing would get selected and scraped:

```
NAME                            TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE   LABELS
cluster1-dc1-all-pods-service   ClusterIP   None           <none>        9042/TCP,8080/TCP,9103/TCP   90m   app.kubernetes.io/managed-by=cass-operator,cassandra.datastax.com/cluster=cluster1,cassandra.datastax.com/datacenter=newflood-dc1
cluster1-dc1-service            ClusterIP   None           <none>        9042/TCP,8080/TCP,9103/TCP   90m   app.kubernetes.io/managed-by=cass-operator,cassandra.datastax.com/cluster=cluster1,cassandra.datastax.com/datacenter=newflood-dc1
```

cc @jimdickinson 

Fixes #276 