### PR TITLE
Configure stuck pod timeout

### DIFF
--- a/charts/cass-operator-chart/templates/customresourcedefinition.yaml
+++ b/charts/cass-operator-chart/templates/customresourcedefinition.yaml
@@ -148,7 +148,7 @@ spec:
               additionalProperties:
                 type: string
               description: 'A map of label keys and values to restrict Cassandra node
-                scheduling to k8s worker with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                scheduling to k8s workers with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
               type: object
             podTemplateSpec:
               description: PodTemplate provides customisation options (labels, annotations,

--- a/charts/cass-operator-chart/templates/customresourcedefinition.yaml
+++ b/charts/cass-operator-chart/templates/customresourcedefinition.yaml
@@ -148,7 +148,7 @@ spec:
               additionalProperties:
                 type: string
               description: 'A map of label keys and values to restrict Cassandra node
-                scheduling to k8s workers with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                scheduling to k8s worker with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
               type: object
             podTemplateSpec:
               description: PodTemplate provides customisation options (labels, annotations,
@@ -6217,6 +6217,11 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            terminateStuckPodsAfterMinutes:
+              description: Determines how many minutes a pod is allowed to exist after
+                losing readiness before it will automatically be terminated and replaced.
+                Default is 10 minutes. Set to 0 to disable
+              type: integer
             users:
               description: Cassandra users to bootstrap
               items:

--- a/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
+++ b/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
@@ -148,7 +148,7 @@ spec:
               additionalProperties:
                 type: string
               description: 'A map of label keys and values to restrict Cassandra node
-                scheduling to k8s worker with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                scheduling to k8s workers with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
               type: object
             podTemplateSpec:
               description: PodTemplate provides customisation options (labels, annotations,

--- a/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
+++ b/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
@@ -148,7 +148,7 @@ spec:
               additionalProperties:
                 type: string
               description: 'A map of label keys and values to restrict Cassandra node
-                scheduling to k8s workers with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                scheduling to k8s worker with matchiing labels. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
               type: object
             podTemplateSpec:
               description: PodTemplate provides customisation options (labels, annotations,
@@ -6207,6 +6207,11 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            terminateStuckPodsAfterMinutes:
+              description: Determines how many minutes a pod is allowed to exist after
+                losing readiness before it will automatically be terminated and replaced.
+                Default is 10 minutes. Set to 0 to disable
+              type: integer
             users:
               description: Cassandra users to bootstrap
               items:

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -146,7 +146,7 @@ type CassandraDatacenterSpec struct {
 	// to false once the restart is in progress.
 	RollingRestartRequested bool `json:"rollingRestartRequested,omitempty"`
 
-	// A map of label keys and values to restrict Cassandra node scheduling to k8s worker
+	// A map of label keys and values to restrict Cassandra node scheduling to k8s workers
 	// with matchiing labels.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -146,7 +146,7 @@ type CassandraDatacenterSpec struct {
 	// to false once the restart is in progress.
 	RollingRestartRequested bool `json:"rollingRestartRequested,omitempty"`
 
-	// A map of label keys and values to restrict Cassandra node scheduling to k8s workers
+	// A map of label keys and values to restrict Cassandra node scheduling to k8s worker
 	// with matchiing labels.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
@@ -169,6 +169,12 @@ type CassandraDatacenterSpec struct {
 	AdditionalSeeds []string `json:"additionalSeeds,omitempty"`
 
 	Reaper *ReaperConfig `json:"reaper,omitempty"`
+
+	// Determines how many minutes a pod is allowed to exist after
+	// losing readiness before it will automatically be terminated
+	// and replaced.
+	// Default is 10 minutes. Set to 0 to disable
+	TerminateStuckPodsAfterMinutes *int `json:"terminateStuckPodsAfterMinutes,omitempty"`
 }
 
 type NetworkingConfig struct {
@@ -201,6 +207,14 @@ type DseWorkloads struct {
 
 type StorageConfig struct {
 	CassandraDataVolumeClaimSpec *corev1.PersistentVolumeClaimSpec `json:"cassandraDataVolumeClaimSpec,omitempty"`
+}
+
+func (dc *CassandraDatacenter) GetPodTerminationTimeout() int {
+	if dc.Spec.TerminateStuckPodsAfterMinutes == nil {
+		return 10
+	}
+
+	return *dc.Spec.TerminateStuckPodsAfterMinutes
 }
 
 // GetRacks is a getter for the Rack slice in the spec

--- a/operator/pkg/apis/cassandra/v1beta1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/cassandra/v1beta1/zz_generated.deepcopy.go
@@ -142,6 +142,11 @@ func (in *CassandraDatacenterSpec) DeepCopyInto(out *CassandraDatacenterSpec) {
 		*out = new(ReaperConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TerminateStuckPodsAfterMinutes != nil {
+		in, out := &in.TerminateStuckPodsAfterMinutes, &out.TerminateStuckPodsAfterMinutes
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/delete_node_allow_disable/delete_node_allow_disable_suite_test.go
+++ b/tests/delete_node_allow_disable/delete_node_allow_disable_suite_test.go
@@ -1,0 +1,110 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package delete_node_allow_disable
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ginkgo_util "github.com/datastax/cass-operator/mage/ginkgo"
+	"github.com/datastax/cass-operator/mage/kubectl"
+)
+
+var (
+	testName     = "Disable deletion of node that lost readiness and isn't becoming ready"
+	namespace    = "test-disable-delete-node-lost-readiness"
+	dcName       = "dc1"
+	dcYaml       = "../testdata/default-three-rack-three-node-disable-delete-stuck-nodes.yaml"
+	operatorYaml = "../testdata/operator.yaml"
+	dcResource   = fmt.Sprintf("CassandraDatacenter/%s", dcName)
+	dcLabel      = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)
+	ns           = ginkgo_util.NewWrapper(testName, namespace)
+)
+
+func TestLifecycle(t *testing.T) {
+	AfterSuite(func() {
+		logPath := fmt.Sprintf("%s/aftersuite", ns.LogDir)
+		kubectl.DumpAllLogs(logPath).ExecV()
+		fmt.Printf("\n\tPost-run logs dumped at: %s\n\n", logPath)
+		ns.Terminate()
+	})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, testName)
+}
+
+var _ = Describe(testName, func() {
+	Context("when in a new cluster", func() {
+		Specify("the operator can detect a node that lost readiness and is hanging, and doesn't delete the pod when is configured not to", func() {
+			By("creating a namespace")
+			err := kubectl.CreateNamespace(namespace).ExecV()
+			Expect(err).ToNot(HaveOccurred())
+
+			step := "setting up cass-operator resources via helm chart"
+			ns.HelmInstall("../../charts/cass-operator-chart")
+
+			ns.WaitForOperatorReady()
+
+			step = "creating a datacenter resource with 3 racks/3 nodes"
+			k := kubectl.ApplyFiles(dcYaml)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterReady(dcName)
+
+			podNames := ns.GetDatacenterPodNames(dcName)
+			podName := podNames[0]
+
+			step = "verifying that the pod is labeled as Started"
+			json := `jsonpath={.metadata.labels.cassandra\.datastax\.com/node-state}`
+			k = kubectl.GetByTypeAndName("pod", podName).
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "Started", 120)
+
+			ns.DisableGossip(podName)
+
+			step = "verifying that the pod lost readiness"
+			json = "jsonpath={.status.containerStatuses[0].ready}"
+			k = kubectl.GetByTypeAndName("pod", podName).
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "false", 60)
+
+			// allow a total of 11 minutes to pass to verify that the pod doesn't get deleted
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+			waitOneMinuteAndVerifyPodNeverTerminates(podName)
+
+			step = "deleting the dc"
+			k = kubectl.DeleteFromFiles(dcYaml)
+			ns.ExecAndLog(step, k)
+
+			step = "checking that the dc no longer exists"
+			json = "jsonpath={.items}"
+			k = kubectl.Get("CassandraDatacenter").
+				WithLabel(dcLabel).
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "[]", 300)
+		})
+	})
+})
+
+func waitOneMinuteAndVerifyPodNeverTerminates(podName string) {
+	time.Sleep(time.Second * 60)
+	By("waiting one minute and checking that pod didn't terminate")
+	json := "jsonpath={.metadata.deletionTimestamp}"
+	k := kubectl.GetByTypeAndName("pod", podName).
+		FormatOutput(json)
+	ns.WaitForOutput(k, "", 5)
+}

--- a/tests/testdata/default-three-rack-three-node-disable-delete-stuck-nodes.yaml
+++ b/tests/testdata/default-three-rack-three-node-disable-delete-stuck-nodes.yaml
@@ -1,0 +1,31 @@
+apiVersion: cassandra.datastax.com/v1beta1
+kind: CassandraDatacenter
+metadata:
+  name: dc1
+spec:
+  clusterName: cluster1
+  serverType: dse
+  serverVersion: "6.8.4"
+  terminateStuckPodsAfterMinutes: 0
+  managementApiAuth:
+    insecure: {}
+  size: 3
+  storageConfig:
+      cassandraDataVolumeClaimSpec:
+        storageClassName: server-storage
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  racks:
+    - name: r1
+    - name: r2
+    - name: r3
+  config:
+    jvm-server-options:
+      initial_heap_size: "800m"
+      max_heap_size: "800m"
+    cassandra-yaml:
+      file_cache_size_in_mb: 100
+      memtable_space_in_mb: 100


### PR DESCRIPTION
Support configuration of the timeout in which we will delete a stuck pod. 

Setting to 0 will disable the stuck check. 10 minutes is the default (same as current behavior)