### PR TITLE
operator/pkg/images: Allow busybox image to be set by the user

### DIFF
--- a/operator/pkg/images/images.go
+++ b/operator/pkg/images/images.go
@@ -20,6 +20,7 @@ const (
 	envDefaultRegistryOverride            = "DEFAULT_CONTAINER_REGISTRY_OVERRIDE"
 	envDefaultRegistryOverridePullSecrets = "DEFAULT_CONTAINER_REGISTRY_OVERRIDE_PULL_SECRETS"
 	EnvBaseImageOS                        = "BASE_IMAGE_OS"
+	EnvBusyboxImage                       = "BUSYBOX_IMAGE"
 	ValidDseVersionRegexp                 = "6\\.8\\.\\d+"
 	ValidOssVersionRegexp                 = "(3\\.11\\.\\d+)|(4\\.0\\.\\d+)"
 	UbiImageSuffix                        = "-ubi7"
@@ -99,8 +100,7 @@ var imageLookupMap map[Image]string = map[Image]string{
 	ConfigBuilder:    "datastax/cass-config-builder:1.0.3",
 	UBIConfigBuilder: "datastax/cass-config-builder:1.0.3-ubi7",
 
-	BusyBox: "busybox",
-	Reaper:  "thelastpickle/cassandra-reaper:2.0.5",
+	Reaper: "thelastpickle/cassandra-reaper:2.0.5",
 }
 
 var versionToOSSCassandra map[string]Image = map[string]Image{
@@ -181,9 +181,17 @@ func CalculateDockerImageRunsAsCassandra(version string) bool {
 func GetImage(name Image) string {
 	image, ok := imageLookupMap[name]
 	if !ok {
-		if name == BaseImageOS {
+		switch name {
+		case BaseImageOS:
 			image = os.Getenv(EnvBaseImageOS)
-		} else {
+
+		case BusyBox:
+			image = "busybox"
+			if v := os.Getenv(EnvBusyboxImage); v != "" {
+				image = v
+			}
+
+		default:
 			// This should never happen as we have a unit test
 			// to ensure imageLookupMap is fully populated.
 			log.Error(nil, "Could not find image", "image", int(name))

--- a/operator/pkg/images/images.go
+++ b/operator/pkg/images/images.go
@@ -20,7 +20,6 @@ const (
 	envDefaultRegistryOverride            = "DEFAULT_CONTAINER_REGISTRY_OVERRIDE"
 	envDefaultRegistryOverridePullSecrets = "DEFAULT_CONTAINER_REGISTRY_OVERRIDE_PULL_SECRETS"
 	EnvBaseImageOS                        = "BASE_IMAGE_OS"
-	EnvBusyboxImage                       = "BUSYBOX_IMAGE"
 	ValidDseVersionRegexp                 = "6\\.8\\.\\d+"
 	ValidOssVersionRegexp                 = "(3\\.11\\.\\d+)|(4\\.0\\.\\d+)"
 	UbiImageSuffix                        = "-ubi7"
@@ -100,7 +99,8 @@ var imageLookupMap map[Image]string = map[Image]string{
 	ConfigBuilder:    "datastax/cass-config-builder:1.0.3",
 	UBIConfigBuilder: "datastax/cass-config-builder:1.0.3-ubi7",
 
-	Reaper: "thelastpickle/cassandra-reaper:2.0.5",
+	BusyBox: "busybox:1.32.0-uclibc",
+	Reaper:  "thelastpickle/cassandra-reaper:2.0.5",
 }
 
 var versionToOSSCassandra map[string]Image = map[string]Image{
@@ -181,17 +181,9 @@ func CalculateDockerImageRunsAsCassandra(version string) bool {
 func GetImage(name Image) string {
 	image, ok := imageLookupMap[name]
 	if !ok {
-		switch name {
-		case BaseImageOS:
+		if name == BaseImageOS {
 			image = os.Getenv(EnvBaseImageOS)
-
-		case BusyBox:
-			image = "busybox"
-			if v := os.Getenv(EnvBusyboxImage); v != "" {
-				image = v
-			}
-
-		default:
+		} else {
 			// This should never happen as we have a unit test
 			// to ensure imageLookupMap is fully populated.
 			log.Error(nil, "Could not find image", "image", int(name))


### PR DESCRIPTION
Thank you for taking the time to look at this pull request!

In some Kubernetes environments, the operators may opt to set up [ImagePolicyWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#imagepolicywebhook) or any other validating admission webhook (or admission controller) to restrict the registry or tags of the images that are deployed. If an image tag is not specified, it defaults to `latest`. In my case, we have an admission webhook which prevents us from deploying any images' `latest` tag.

In this pull request, the default Busybox image is still `busybox`, but the user can set the `BUSYBOX_IMAGE` environment variable to either lock the busybox image to a specific version, and/or use a different image registry.