### PR TITLE
retrying decommission instead of assuming it works

### DIFF
--- a/operator/pkg/reconciliation/check_nodes.go
+++ b/operator/pkg/reconciliation/check_nodes.go
@@ -137,24 +137,12 @@ func (rc *ReconciliationContext) GetAllNodes() ([]*corev1.Node, error) {
 	if err := rc.Client.List(rc.Ctx, nodeList, listOptions); err != nil {
 		return nil, err
 	}
-
-	agentNodesIndex := []int{}
-
-	for i, node := range nodeList.Items {
-		if isAgent(node) {
-			agentNodesIndex = append(agentNodesIndex, i)
-		}
-	}
-	nodes := make([]*corev1.Node, len(agentNodesIndex))
-
-	for i, index := range agentNodesIndex {
-		nodes[i] = &nodeList.Items[index]
+	nodeCount := len(nodeList.Items)
+	nodes := make([]*corev1.Node, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		nodes[i] = &nodeList.Items[i]
 	}
 	return nodes, nil
-}
-
-func isAgent(node corev1.Node) bool {
-	return node.Labels["kubernetes.io/role"] == "agent"
 }
 
 func (rc *ReconciliationContext) GetDCPods() []*corev1.Pod {

--- a/operator/pkg/reconciliation/check_nodes.go
+++ b/operator/pkg/reconciliation/check_nodes.go
@@ -137,11 +137,24 @@ func (rc *ReconciliationContext) GetAllNodes() ([]*corev1.Node, error) {
 	if err := rc.Client.List(rc.Ctx, nodeList, listOptions); err != nil {
 		return nil, err
 	}
-	var nodes []*corev1.Node
-	for _, node := range nodeList.Items {
-		nodes = append(nodes, &node)
+
+	agentNodesIndex := []int{}
+
+	for i, node := range nodeList.Items {
+		if isAgent(node) {
+			agentNodesIndex = append(agentNodesIndex, i)
+		}
+	}
+	nodes := make([]*corev1.Node, len(agentNodesIndex))
+
+	for i, index := range agentNodesIndex {
+		nodes[i] = &nodeList.Items[index]
 	}
 	return nodes, nil
+}
+
+func isAgent(node corev1.Node) bool {
+	return node.Labels["kubernetes.io/role"] == "agent"
 }
 
 func (rc *ReconciliationContext) GetDCPods() []*corev1.Pod {

--- a/operator/pkg/reconciliation/decommission_node_test.go
+++ b/operator/pkg/reconciliation/decommission_node_test.go
@@ -1,0 +1,157 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package reconciliation
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/datastax/cass-operator/operator/internal/result"
+	api "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	"github.com/datastax/cass-operator/operator/pkg/httphelper"
+	"github.com/datastax/cass-operator/operator/pkg/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRetryDecommissionNode(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+	state := "UP"
+	podIP := "192.168.101.11"
+
+	mockClient := &mocks.Client{}
+	rc.Client = mockClient
+
+	rc.Datacenter.SetCondition(api.DatacenterCondition{
+		Status: v1.ConditionTrue,
+		Type:   api.DatacenterScalingDown,
+	})
+	res := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       ioutil.NopCloser(strings.NewReader("OK")),
+	}
+	mockHttpClient := &mocks.HttpClient{}
+	mockHttpClient.On("Do",
+		mock.MatchedBy(
+			func(req *http.Request) bool {
+				return req.URL.Path == "/api/v0/ops/node/decommission"
+			})).
+		Return(res, nil).
+		Once()
+
+	rc.NodeMgmtClient = httphelper.NodeMgmtClient{
+		Client:   mockHttpClient,
+		Log:      rc.ReqLogger,
+		Protocol: "http",
+	}
+
+	labels := make(map[string]string)
+	labels[api.CassNodeState] = stateDecommissioning
+
+	rc.dcPods = []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pod-1",
+			Labels: labels,
+		},
+		Status: v1.PodStatus{
+			PodIP: podIP,
+		},
+	}}
+
+	epData := httphelper.CassMetadataEndpoints{
+		Entity: []httphelper.EndpointState{
+			{
+				RpcAddress: podIP,
+				Status:     state,
+			},
+		},
+	}
+	r := rc.CheckDecommissioningNodes(epData)
+	if r != result.RequeueSoon(5) {
+		t.Fatalf("expected result of result.RequeueSoon(5) but got %s", r)
+	}
+}
+
+func TestRemoveResourcesWhenDone(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+	podIP := "192.168.101.11"
+	state := "LEFT"
+
+	mockClient := &mocks.Client{}
+	rc.Client = mockClient
+	rc.Datacenter.SetCondition(api.DatacenterCondition{
+		Status: v1.ConditionTrue,
+		Type:   api.DatacenterScalingDown,
+	})
+	mockStatus := &statusMock{}
+	k8sMockClientStatus(mockClient, mockStatus)
+
+	labels := make(map[string]string)
+	labels[api.CassNodeState] = stateDecommissioning
+
+	rc.dcPods = []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pod-1",
+			Labels: labels,
+		},
+		Status: v1.PodStatus{
+			PodIP: podIP,
+		},
+	}}
+
+	makeInt := func(i int32) *int32 {
+		return &i
+	}
+	ssLabels := make(map[string]string)
+	rc.statefulSets = []*appsv1.StatefulSet{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ss-1",
+			Labels: ssLabels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: makeInt(1),
+		},
+	}}
+
+	epData := httphelper.CassMetadataEndpoints{
+		Entity: []httphelper.EndpointState{
+			{
+				RpcAddress: podIP,
+				Status:     state,
+			},
+		},
+	}
+
+	r := rc.CheckDecommissioningNodes(epData)
+	if r != result.RequeueSoon(5) {
+		t.Fatalf("expected result of blah but got %s", r)
+	}
+	if mockStatus.called != 1 {
+		t.Fatalf("expected 1 call to mockStatus but had %v", mockStatus.called)
+	}
+}
+
+type statusMock struct {
+	called int
+}
+
+func (s *statusMock) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+func (s *statusMock) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	s.called = s.called + 1
+	return nil
+}

--- a/operator/pkg/reconciliation/testing.go
+++ b/operator/pkg/reconciliation/testing.go
@@ -184,6 +184,24 @@ func k8sMockClientGet(mockClient *mocks.Client, returnArg interface{}) *mock.Cal
 		Once()
 }
 
+func k8sMockClientStatus(mockClient *mocks.Client, returnArg interface{}) *mock.Call {
+	return mockClient.On("Status",
+		mock.MatchedBy(
+			func(ctx context.Context) bool {
+				return ctx != nil
+			}),
+		mock.MatchedBy(
+			func(key client.ObjectKey) bool {
+				return key != client.ObjectKey{}
+			}),
+		mock.MatchedBy(
+			func(obj runtime.Object) bool {
+				return obj != nil
+			})).
+		Return(returnArg).
+		Once()
+}
+
 func k8sMockClientUpdate(mockClient *mocks.Client, returnArg interface{}) *mock.Call {
 	return mockClient.On("Update",
 		mock.MatchedBy(

--- a/operator/pkg/reconciliation/testing.go
+++ b/operator/pkg/reconciliation/testing.go
@@ -185,19 +185,7 @@ func k8sMockClientGet(mockClient *mocks.Client, returnArg interface{}) *mock.Cal
 }
 
 func k8sMockClientStatus(mockClient *mocks.Client, returnArg interface{}) *mock.Call {
-	return mockClient.On("Status",
-		mock.MatchedBy(
-			func(ctx context.Context) bool {
-				return ctx != nil
-			}),
-		mock.MatchedBy(
-			func(key client.ObjectKey) bool {
-				return key != client.ObjectKey{}
-			}),
-		mock.MatchedBy(
-			func(obj runtime.Object) bool {
-				return obj != nil
-			})).
+	return mockClient.On("Status").
 		Return(returnArg).
 		Once()
 }


### PR DESCRIPTION
We were hitting a corner where if the decom never succesfully regsitered on the node it would never try again and the cluster would be stuck in a decom state that could never come.

highlights
- now check for to see if the decommission actually started and then retrying the decommission if it has not
- now logging decommission service errors. this is probably needless but once the mgmt api in dse gets more solid and can handle returning a "started startus" and we can do some proper error handling the logging maybe useful.

NOTE: labeling this as a wip to get some tests running but this appears to work