### PR TITLE
Reduce dependencies of apis/CassandraDatacenter to allow newer Kubernetes

### DIFF
--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -8,14 +8,11 @@ import (
 	"fmt"
 
 	"github.com/Jeffail/gabs"
+	"github.com/datastax/cass-operator/operator/pkg/serverconfig"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/datastax/cass-operator/operator/pkg/images"
-	"github.com/datastax/cass-operator/operator/pkg/serverconfig"
-	"github.com/datastax/cass-operator/operator/pkg/utils"
 )
 
 const (
@@ -398,11 +395,7 @@ func init() {
 }
 
 func (dc *CassandraDatacenter) GetConfigBuilderImage() string {
-	if dc.Spec.ConfigBuilderImage != "" {
-		return dc.Spec.ConfigBuilderImage
-	} else {
-		return images.GetConfigBuilderImage()
-	}
+	return dc.Spec.ConfigBuilderImage
 }
 
 // GetServerImage produces a fully qualified container image to pull
@@ -410,31 +403,14 @@ func (dc *CassandraDatacenter) GetConfigBuilderImage() string {
 //
 // In the event that no valid image could be retrieved from the specified version,
 // an error is returned.
-func (dc *CassandraDatacenter) GetServerImage() (string, error) {
-	return makeImage(dc.Spec.ServerType, dc.Spec.ServerVersion, dc.Spec.ServerImage)
-}
-
-// makeImage takes the server type/version and image from the spec,
-// and returns a docker pullable server container image
-// serverVersion should be a semver-like string
-// serverImage should be an empty string, or [hostname[:port]/][path/with/repo]:[Server container img tag]
-// If serverImage is empty, we attempt to find an appropriate container image based on the serverVersion
-// In the event that no image is found, an error is returned
-func makeImage(serverType, serverVersion, serverImage string) (string, error) {
-	if serverImage == "" {
-		return images.GetCassandraImage(serverType, serverVersion)
-	}
-	return serverImage, nil
+func (dc *CassandraDatacenter) GetServerImage() string {
+	return dc.Spec.ServerImage
 }
 
 // GetRackLabels ...
 func (dc *CassandraDatacenter) GetRackLabels(rackName string) map[string]string {
-	labels := map[string]string{
-		RackLabel: rackName,
-	}
-
-	utils.MergeMap(labels, dc.GetDatacenterLabels())
-
+	labels := dc.GetDatacenterLabels()
+	labels[RackLabel] = rackName
 	return labels
 }
 
@@ -491,12 +467,8 @@ func (dc *CassandraDatacenter) SetCondition(condition DatacenterCondition) {
 
 // GetDatacenterLabels ...
 func (dc *CassandraDatacenter) GetDatacenterLabels() map[string]string {
-	labels := map[string]string{
-		DatacenterLabel: dc.Name,
-	}
-
-	utils.MergeMap(labels, dc.GetClusterLabels())
-
+	labels := dc.GetClusterLabels()
+	labels[DatacenterLabel] = dc.Name
 	return labels
 }
 

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -4,201 +4,12 @@
 package v1beta1
 
 import (
-	"os"
 	"testing"
 
-	"github.com/datastax/cass-operator/operator/pkg/images"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func Test_makeImage(t *testing.T) {
-	type args struct {
-		serverType    string
-		serverImage   string
-		serverVersion string
-	}
-	tests := []struct {
-		name      string
-		args      args
-		want      string
-		errString string
-	}{
-		{
-			name: "test empty image",
-			args: args{
-				serverImage:   "",
-				serverType:    "dse",
-				serverVersion: "6.8.0",
-			},
-			want:      "datastax/dse-server:6.8.0",
-			errString: "",
-		},
-		{
-			name: "test empty image cassandra",
-			args: args{
-				serverImage:   "",
-				serverType:    "cassandra",
-				serverVersion: "3.11.7",
-			},
-			want:      "datastax/cassandra-mgmtapi-3_11_7:v0.1.13",
-			errString: "",
-		},
-		{
-			name: "test private repo server",
-			args: args{
-				serverImage:   "datastax.jfrog.io/secret-debug-image/dse-server:6.8.0-test123",
-				serverType:    "dse",
-				serverVersion: "6.8.0",
-			},
-			want:      "datastax.jfrog.io/secret-debug-image/dse-server:6.8.0-test123",
-			errString: "",
-		},
-		{
-			name: "test unknown dse version",
-			args: args{
-				serverImage:   "",
-				serverType:    "dse",
-				serverVersion: "6.7.0",
-			},
-			want:      "",
-			errString: "server 'dse' and version '6.7.0' do not work together",
-		},
-		{
-			name: "test unknown cassandra version",
-			args: args{
-				serverImage:   "",
-				serverType:    "cassandra",
-				serverVersion: "3.10.0",
-			},
-			want:      "",
-			errString: "server 'cassandra' and version '3.10.0' do not work together",
-		},
-		{
-			name: "test fallback",
-			args: args{
-				serverImage:   "",
-				serverType:    "dse",
-				serverVersion: "6.8.1234",
-			},
-			want:      "datastax/dse-server:6.8.1234",
-			errString: "",
-		},
-		{
-			name: "test cassandra fallback",
-			args: args{
-				serverImage:   "",
-				serverType:    "cassandra",
-				serverVersion: "3.11.1234",
-			},
-			want:      "datastax/cassandra-mgmtapi:3.11.1234",
-			errString: "",
-		},
-		{
-			name: "test 6.8.4",
-			args: args{
-				serverImage:   "",
-				serverType:    "dse",
-				serverVersion: "6.8.4",
-			},
-			want:      "datastax/dse-server:6.8.4",
-			errString: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := makeImage(tt.args.serverType, tt.args.serverVersion, tt.args.serverImage)
-			if got != tt.want {
-				t.Errorf("makeImage() = %v, want %v", got, tt.want)
-			}
-			if err == nil {
-				if tt.errString != "" {
-					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
-				}
-			} else {
-				if err.Error() != tt.errString {
-					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
-				}
-			}
-		})
-	}
-}
-
-func Test_makeUbiImage(t *testing.T) {
-	type args struct {
-		serverType    string
-		serverImage   string
-		serverVersion string
-	}
-	tests := []struct {
-		name      string
-		args      args
-		want      string
-		errString string
-	}{
-		{
-			name: "test fallback",
-			args: args{
-				serverImage:   "",
-				serverType:    "dse",
-				serverVersion: "6.8.1234",
-			},
-			want:      "datastax/dse-server:6.8.1234-ubi7",
-			errString: "",
-		},
-		{
-			name: "test cassandra fallback",
-			args: args{
-				serverImage:   "",
-				serverType:    "cassandra",
-				serverVersion: "4.0.1234",
-			},
-			want:      "datastax/cassandra-mgmtapi:4.0.1234-ubi7",
-			errString: "",
-		},
-		{
-			name: "test unknown dse version",
-			args: args{
-				serverImage:   "",
-				serverType:    "dse",
-				serverVersion: "6.7.0",
-			},
-			want:      "",
-			errString: "server 'dse' and version '6.7.0' do not work together",
-		},
-		{
-			name: "test unknown cassandra version",
-			args: args{
-				serverImage:   "",
-				serverType:    "cassandra",
-				serverVersion: "3.10.0",
-			},
-			want:      "",
-			errString: "server 'cassandra' and version '3.10.0' do not work together",
-		},
-	}
-	for _, tt := range tests {
-		os.Setenv(images.EnvBaseImageOS, "example")
-
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := makeImage(tt.args.serverType, tt.args.serverVersion, tt.args.serverImage)
-			if got != tt.want {
-				t.Errorf("makeImage() = %v, want %v", got, tt.want)
-			}
-			if err == nil {
-				if tt.errString != "" {
-					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
-				}
-			} else {
-				if err.Error() != tt.errString {
-					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
-				}
-			}
-		})
-		os.Unsetenv(images.EnvBaseImageOS)
-	}
-}
 
 func TestCassandraDatacenter_GetServerImage(t *testing.T) {
 	type fields struct {
@@ -244,20 +55,10 @@ func TestCassandraDatacenter_GetServerImage(t *testing.T) {
 				Spec:       tt.fields.Spec,
 				Status:     tt.fields.Status,
 			}
-			got, err := dc.GetServerImage()
+			got := dc.GetServerImage()
 			if got != tt.want {
 				t.Errorf("CassandraDatacenter.GetServerImage() = %v, want %v", got, tt.want)
 			}
-			if err == nil {
-				if tt.errString != "" {
-					t.Errorf("CassandraDatacenter.GetServerImage() err = %v, want %v", err, tt.errString)
-				}
-			} else {
-				if err.Error() != tt.errString {
-					t.Errorf("CassandraDatacenter.GetServerImage() err = %v, want %v", err, tt.errString)
-				}
-			}
-
 		})
 	}
 }

--- a/operator/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/operator/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -4,12 +4,14 @@
 package reconciliation
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	api "github.com/datastax/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	"github.com/datastax/cass-operator/operator/pkg/images"
 	"github.com/datastax/cass-operator/operator/pkg/oplabels"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -417,7 +419,7 @@ func TestCassandraDatacenter_buildPodTemplateSpec_add_initContainer_after_config
 	// initContainer.
 
 	initContainer := corev1.Container{
-		Name: "test-container",
+		Name:  "test-container",
 		Image: "test-image",
 	}
 
@@ -464,19 +466,19 @@ func TestCassandraDatacenter_buildPodTemplateSpec_add_initContainer_with_volumes
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						{
-							Name: "test",
+							Name:  "test",
 							Image: "test",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name: "server-data",
+									Name:      "server-data",
 									MountPath: "/var/lib/cassandra",
 								},
 								{
-									Name: "server-config",
+									Name:      "server-config",
 									MountPath: "/config",
 								},
 								{
-									Name: "test-data",
+									Name:      "test-data",
 									MountPath: "/test",
 								},
 							},
@@ -559,19 +561,19 @@ func TestCassandraDatacenter_buildPodTemplateSpec_add_container_with_volumes(t *
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "test",
+							Name:  "test",
 							Image: "test",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name: "server-data",
+									Name:      "server-data",
 									MountPath: "/var/lib/cassandra",
 								},
 								{
-									Name: "server-config",
+									Name:      "server-config",
 									MountPath: "/config",
 								},
 								{
-									Name: "test-data",
+									Name:      "test-data",
 									MountPath: "/test",
 								},
 							},
@@ -580,7 +582,7 @@ func TestCassandraDatacenter_buildPodTemplateSpec_add_container_with_volumes(t *
 							Name: "cassandra",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name: "test-data",
+									Name:      "test-data",
 									MountPath: "/test",
 								},
 							},
@@ -766,7 +768,6 @@ func TestCassandraDatacenter_buildPodTemplateSpec_do_not_propagate_volumes(t *te
 	assert.True(t, volumeMountsContains(serverConfigInitContainer.VolumeMounts, volumeMountNameMatcher("server-config")))
 	assert.True(t, volumeMountsContains(serverConfigInitContainer.VolumeMounts, volumeMountNameMatcher("extra")))
 
-
 	containers := spec.Spec.Containers
 	cassandraContainer := findContainer(containers, CassandraContainerName)
 	assert.NotNil(t, cassandraContainer)
@@ -831,4 +832,205 @@ func TestCassandraDatacenter_buildContainers_EnableSystemLoggerSidecar_CustomIma
 	assert.Equal(t, "server-system-logger", podTemplateSpec.Spec.Containers[1].Name)
 
 	assert.Equal(t, "alpine", podTemplateSpec.Spec.Containers[1].Image)
+}
+
+func Test_makeImage(t *testing.T) {
+	type args struct {
+		serverType    string
+		serverImage   string
+		serverVersion string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      string
+		errString string
+	}{
+		{
+			name: "test empty image",
+			args: args{
+				serverImage:   "",
+				serverType:    "dse",
+				serverVersion: "6.8.0",
+			},
+			want:      "datastax/dse-server:6.8.0",
+			errString: "",
+		},
+		{
+			name: "test empty image cassandra",
+			args: args{
+				serverImage:   "",
+				serverType:    "cassandra",
+				serverVersion: "3.11.7",
+			},
+			want:      "datastax/cassandra-mgmtapi-3_11_7:v0.1.13",
+			errString: "",
+		},
+		{
+			name: "test private repo server",
+			args: args{
+				serverImage:   "datastax.jfrog.io/secret-debug-image/dse-server:6.8.0-test123",
+				serverType:    "dse",
+				serverVersion: "6.8.0",
+			},
+			want:      "datastax.jfrog.io/secret-debug-image/dse-server:6.8.0-test123",
+			errString: "",
+		},
+		{
+			name: "test unknown dse version",
+			args: args{
+				serverImage:   "",
+				serverType:    "dse",
+				serverVersion: "6.7.0",
+			},
+			want:      "",
+			errString: "server 'dse' and version '6.7.0' do not work together",
+		},
+		{
+			name: "test unknown cassandra version",
+			args: args{
+				serverImage:   "",
+				serverType:    "cassandra",
+				serverVersion: "3.10.0",
+			},
+			want:      "",
+			errString: "server 'cassandra' and version '3.10.0' do not work together",
+		},
+		{
+			name: "test fallback",
+			args: args{
+				serverImage:   "",
+				serverType:    "dse",
+				serverVersion: "6.8.1234",
+			},
+			want:      "datastax/dse-server:6.8.1234",
+			errString: "",
+		},
+		{
+			name: "test cassandra fallback",
+			args: args{
+				serverImage:   "",
+				serverType:    "cassandra",
+				serverVersion: "3.11.1234",
+			},
+			want:      "datastax/cassandra-mgmtapi:3.11.1234",
+			errString: "",
+		},
+		{
+			name: "test 6.8.4",
+			args: args{
+				serverImage:   "",
+				serverType:    "dse",
+				serverVersion: "6.8.4",
+			},
+			want:      "datastax/dse-server:6.8.4",
+			errString: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dc := &api.CassandraDatacenter{
+				Spec: api.CassandraDatacenterSpec{
+					ServerType:    tt.args.serverType,
+					ServerVersion: tt.args.serverVersion,
+					ServerImage:   tt.args.serverImage,
+				},
+			}
+			got, err := makeImage(dc)
+			if got != tt.want {
+				t.Errorf("makeImage() = %v, want %v", got, tt.want)
+			}
+			if err == nil {
+				if tt.errString != "" {
+					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
+				}
+			} else {
+				if err.Error() != tt.errString {
+					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
+				}
+			}
+		})
+	}
+}
+
+func Test_makeUbiImage(t *testing.T) {
+	type args struct {
+		serverType    string
+		serverImage   string
+		serverVersion string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      string
+		errString string
+	}{
+		{
+			name: "test fallback",
+			args: args{
+				serverImage:   "",
+				serverType:    "dse",
+				serverVersion: "6.8.1234",
+			},
+			want:      "datastax/dse-server:6.8.1234-ubi7",
+			errString: "",
+		},
+		{
+			name: "test cassandra fallback",
+			args: args{
+				serverImage:   "",
+				serverType:    "cassandra",
+				serverVersion: "4.0.1234",
+			},
+			want:      "datastax/cassandra-mgmtapi:4.0.1234-ubi7",
+			errString: "",
+		},
+		{
+			name: "test unknown dse version",
+			args: args{
+				serverImage:   "",
+				serverType:    "dse",
+				serverVersion: "6.7.0",
+			},
+			want:      "",
+			errString: "server 'dse' and version '6.7.0' do not work together",
+		},
+		{
+			name: "test unknown cassandra version",
+			args: args{
+				serverImage:   "",
+				serverType:    "cassandra",
+				serverVersion: "3.10.0",
+			},
+			want:      "",
+			errString: "server 'cassandra' and version '3.10.0' do not work together",
+		},
+	}
+	for _, tt := range tests {
+		os.Setenv(images.EnvBaseImageOS, "example")
+
+		t.Run(tt.name, func(t *testing.T) {
+			dc := &api.CassandraDatacenter{
+				Spec: api.CassandraDatacenterSpec{
+					ServerType:    tt.args.serverType,
+					ServerVersion: tt.args.serverVersion,
+					ServerImage:   tt.args.serverImage,
+				},
+			}
+			got, err := makeImage(dc)
+			if got != tt.want {
+				t.Errorf("makeImage() = %v, want %v", got, tt.want)
+			}
+			if err == nil {
+				if tt.errString != "" {
+					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
+				}
+			} else {
+				if err.Error() != tt.errString {
+					t.Errorf("makeImage() err = %v, want %v", err, tt.errString)
+				}
+			}
+		})
+		os.Unsetenv(images.EnvBaseImageOS)
+	}
 }


### PR DESCRIPTION
When using cass-operator's CassandraDatacenter as a dependency in another project, the current implementation prevents the use of newer versions of Kubernetes dependencies (conflicts with certain removed APIs).

These dependencies come from the use of utils package as well as images. Images pulls old controller-runtime which wants old non-existant Kube APIs and the utils picks up also persistentvolume dependencies.

I think the end approach should be that apis does not call other packages inside cass-operator to ensure that it's self contained and can be more easily used in other projects as dependency. However, with these modifications I was able to use CassandraDatacenter as a dependency with Kubernetes versions up to 1.20.4 (newest released), so it solves the problem. serverconfig does not use external packages, but there was a note of code-gen requirement to keep it in the external package - which probably requires updating the controller-runtime to operator-sdk 1.x series - and that's a lot bigger project.