### PR TITLE
Override container user Id from env

### DIFF
--- a/operator/pkg/reconciliation/construct_statefulset.go
+++ b/operator/pkg/reconciliation/construct_statefulset.go
@@ -13,7 +13,9 @@ import (
 	"github.com/datastax/cass-operator/operator/pkg/oplabels"
 	"github.com/datastax/cass-operator/operator/pkg/psp"
 	"github.com/datastax/cass-operator/operator/pkg/utils"
+	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -178,6 +180,11 @@ func newStatefulSetForCassandraDatacenterHelper(
 
 	if shouldDefineSecurityContext(dc) {
 		var userID int64 = 999
+		if userFromEnv := os.Getenv("DSE_USER_ID"); userFromEnv != "" {
+			if inputValue, convErr := strconv.Atoi(userFromEnv); convErr == nil {
+				userID = int64(inputValue)
+			}
+		}
 		template.Spec.SecurityContext = &corev1.PodSecurityContext{
 			RunAsUser:  &userID,
 			RunAsGroup: &userID,


### PR DESCRIPTION
We have a managed Kubernetes Environment where it is enforced that all uids be between 1000 and 65535.
To fix this, we are using DSE image and are creating a user 1000 so our deployment is not rejected.

The operator hard codes the value to 999. This PR defaults the userID to 999 but will try to use the DSE_USER_ID environment variable if provided.
